### PR TITLE
Added more permissions to support role based access

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/security/PermissionConstants.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/security/PermissionConstants.java
@@ -7,4 +7,40 @@ public final class PermissionConstants {
     @SystemPermission(name = "Api user", description = "Has role for api users")
     public static final String PERM_API_USER = "Api User";
 
+    @SystemPermission(name = "View Goals", description = "Can view goals at any level")
+    public static final String PERM_VIEW_GOALS = "View Goals";
+
+    @SystemPermission(name = "Create Goals", description = "Can create goals")
+    public static final String PERM_CREATE_GOALS = "Create Goals";
+
+    @SystemPermission(name = "Edit Goals", description = "Can edit existing goals")
+    public static final String PERM_EDIT_GOALS = "Edit Goals";
+
+    @SystemPermission(name = "Delete Goals", description = "Can delete goals")
+    public static final String PERM_DELETE_GOALS = "Delete Goals";
+
+    @SystemPermission(name = "Manage KPIs", description = "Can create, edit, and delete KPIs")
+    public static final String PERM_MANAGE_KPIS = "Manage KPIs";
+
+    @SystemPermission(name = "View Reports", description = "Can view system reports")
+    public static final String PERM_VIEW_REPORTS = "View Reports";
+
+    @SystemPermission(name = "Manage Review Cycles", description = "Can create and configure review cycles")
+    public static final String PERM_MANAGE_REVIEW_CYCLES = "Manage Review Cycles";
+
+    @SystemPermission(name = "Manage Users", description = "Can create, edit, and delete users")
+    public static final String PERM_MANAGE_USERS = "Manage Users";
+
+    @SystemPermission(name = "Manage Roles", description = "Can create, edit, and delete roles")
+    public static final String PERM_MANAGE_ROLES = "Manage Roles";
+
+    @SystemPermission(name = "Manage Permissions", description = "Can create, edit, and delete permissions")
+    public static final String PERM_MANAGE_PERMISSIONS = "Manage Permissions";
+
+    @SystemPermission(name = "Manage Departments", description = "Can create, edit, and delete departments")
+    public static final String PERM_MANAGE_DEPARTMENTS = "Manage Departments";
+
+    @SystemPermission(name = "Manage Teams", description = "Can create, edit, and delete teams")
+    public static final String PERM_MANAGE_TEAMS = "Manage Teams";
+
 }

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/CustomPermissionRoleMigrations.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/CustomPermissionRoleMigrations.java
@@ -31,7 +31,7 @@ public class CustomPermissionRoleMigrations {
 	PermissionService permissionService;
 
 	@Migration(orderNumber = 1)
-	public void savePermissions() {
+	public void savePermissions2() {
 
 		//Migrating Permissions
 		for (Permission permission : PermissionInterpreter.reflectivelyGetPermissions()) {


### PR DESCRIPTION
#### Description
This PR introduces additional permission constants to support role-based access control testing. Specifically, 10 new generic permissions have been added to PermissionConstants to cover core system features such as goals, KPIs, review cycles, users, roles, and reports.
Additionally, the savePermissions() method in CustomPermissionRoleMigrations has been renamed to savePermissions2() to avoid potential naming conflicts or method overriding issues.
#### Type of change


- [ ] New feature (non-breaking change which adds functionality)

#### How Has This Been Tested?

- [ ] Unit

#### How can this be Tested?
How can this be Tested?

Start the application.

Check the logs to confirm migration runs without errors.

Login as an admin user.

Navigate to the Roles/Permissions management section in the system.

Verify that the new permissions are present in the permission list.

Assign new permissions to any role and confirm access control works as expected.

