### PR TITLE
Feature-Review cycle management frontend

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/ReviewCycleForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/ReviewCycleForm.java
@@ -1,0 +1,93 @@
+package org.pahappa.systems.kpiTracker.views.dialogs.systemSetup;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.impl.ReviewCycleService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.ReviewCycleType;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.model.Gender;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.application.FacesMessage;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import javax.faces.context.FacesContext;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@ManagedBean(name = "reviewCycleForm")
+@Getter
+@Setter
+@SessionScoped
+public class ReviewCycleForm extends DialogForm<ReviewCycle> {
+    private static final long serialVersionUID = 1L;
+    private ReviewCycleService reviewCycleService;
+    private List<ReviewCycleType> reviewCycleTypes = new ArrayList<>();
+
+    public ReviewCycleForm() {
+        super(HyperLinks.REVIEW_CYCLE_DIALOG, 700, 800);
+    }
+
+    @PostConstruct
+    public void init() {
+        this.reviewCycleService = ApplicationContextProvider.getBean(ReviewCycleService.class);
+        this.reviewCycleTypes = Arrays.asList(ReviewCycleType.values());
+    }
+
+    @Override
+    public void persist() throws Exception {
+        if (model.getStartDate() == null || model.getType() == null) {
+            FacesContext.getCurrentInstance().addMessage(null,
+                    new FacesMessage(FacesMessage.SEVERITY_ERROR,
+                            "Missing Information",
+                            "Please select both review cycle type and start date."));
+            return;
+        }
+
+        // Auto-set end date based on type
+        model.setEndDate(calculateEndDate(model.getType(), model.getStartDate()));
+
+        reviewCycleService.saveInstance(super.model);
+    }
+
+
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new ReviewCycle();
+    }
+    private Date calculateEndDate(ReviewCycleType type, Date start) {
+        long daysToAdd;
+        switch (type) {
+            case WEEKLY:
+                daysToAdd = 6; // start day counts as 1
+                break;
+            case MONTHLY:
+                daysToAdd = 30; // approx 1 month
+                break;
+            case QUARTERLY:
+                daysToAdd = 91; // approx 3 months
+                break;
+            case YEARLY:
+                daysToAdd = 365;
+                break;
+            default:
+                daysToAdd = 0;
+        }
+        return new Date(start.getTime() + TimeUnit.DAYS.toMillis(daysToAdd));
+    }
+    public void updateEndDate() {
+        if (model.getStartDate() != null && model.getType() != null) {
+            model.setEndDate(calculateEndDate(model.getType(), model.getStartDate()));
+        }
+    }
+
+
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/ReviewCycleView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/ReviewCycleView.java
@@ -1,0 +1,76 @@
+package org.pahappa.systems.kpiTracker.views.systemSetup;
+
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.impl.ReviewCycleService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.sers.webutils.client.views.presenters.PaginatedTableView;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.List;
+import java.util.Map;
+
+@ManagedBean(name = "reviewCycleView")
+@Setter
+@Getter
+@SessionScoped
+public class ReviewCycleView extends PaginatedTableView<ReviewCycle,ReviewCycleService,ReviewCycleService> {
+
+    private ReviewCycleService reviewCycleService;
+    private Search search;
+
+
+    @PostConstruct
+    public void init(){
+        reviewCycleService = ApplicationContextProvider.getBean(ReviewCycleService.class);
+
+        reloadFilterReset();
+    }
+    @Override
+    public void reloadFromDB(int i, int i1, Map<String, Object> map) throws Exception {
+        super.setDataModels(reviewCycleService.getInstances(new Search().addFilterEqual("recordStatus", RecordStatus.ACTIVE),i,i1));
+    }
+
+    @Override
+    public List<ExcelReport> getExcelReportModels() {
+        return null;
+    }
+
+    @Override
+    public String getFileName() {
+        return null;
+    }
+
+    @Override
+    public List load(int i, int i1, Map map, Map map1) {
+        return null;
+    }
+
+    @Override
+    public void reloadFilterReset(){
+        super.setTotalRecords(reviewCycleService.countInstances(new Search()));
+        try{
+            super.reloadFilterReset();
+        }catch(Exception e){
+            UiUtils.ComposeFailure("Error",e.getLocalizedMessage());
+        }
+
+    }
+
+    public void deleteClient(ReviewCycle reviewCycle) {
+        try {
+            reviewCycleService.deleteInstance(reviewCycle);
+            reloadFilterReset();
+        } catch (OperationFailedException e) {
+            UiUtils.ComposeFailure("Delete Failed", e.getLocalizedMessage());
+        }
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/java/org/pahappa/systems/client/converters/ReviewCycleTypeConverter.java
+++ b/frontend/kpi-tracker-web/src/main/java/org/pahappa/systems/client/converters/ReviewCycleTypeConverter.java
@@ -1,0 +1,40 @@
+package org.pahappa.systems.client.converters;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.ReviewCycleType;
+import org.sers.webutils.model.Gender;
+
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+
+
+@FacesConverter("reviewCycleTypeConverter")
+public class ReviewCycleTypeConverter implements Converter {
+    @Override
+    public Object getAsObject(FacesContext arg0, UIComponent arg1, String arg2) {
+
+        if (arg2.equalsIgnoreCase(ReviewCycleType.QUARTERLY.name())) {
+            return ReviewCycleType.QUARTERLY;
+        }
+
+        if (arg2.equalsIgnoreCase(ReviewCycleType.WEEKLY.name())) {
+            return ReviewCycleType.WEEKLY;
+        }
+
+        if (arg2.equalsIgnoreCase(ReviewCycleType.MONTHLY.name())) {
+            return ReviewCycleType.MONTHLY;
+        }
+        if (arg2.equalsIgnoreCase(ReviewCycleType.YEARLY.name())) {
+            return ReviewCycleType.YEARLY;
+        }
+        return null;
+    }
+
+    @Override
+    public String getAsString(FacesContext arg0, UIComponent arg1, Object object) {
+        if (object == null || object instanceof String)
+            return null;
+        return ((ReviewCycleType) object).name();
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleForm.xhtml
@@ -1,0 +1,71 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/dialog-template.xhtml">
+
+    <ui:define name="head">
+        <style type="text/css">
+            .capitalized { text-transform: capitalize; }
+        </style>
+    </ui:define>
+
+    <ui:define name="content">
+        <title>Add Review Cycle</title>
+        <h:form id="reviewCycleDialog" style="height: 450px" styleClass="card">
+
+            <!-- 1. ADDED GROWL TO DISPLAY MESSAGES -->
+            <p:growl id="growl" showDetail="true" life="4000" />
+
+            <div class="p-grid ui-fluid" style="display:flex; flex-wrap: wrap;">
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Type</h5>
+                    <div class="ui-inputgroup">
+                        <p:selectOneMenu value="#{reviewCycleForm.model.type}">
+                            <f:selectItems value="#{reviewCycleForm.reviewCycleTypes}" />
+                            <p:ajax event="change" update="endDate growl" listener="#{reviewCycleForm.updateEndDate}" />
+                        </p:selectOneMenu>
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Start day</h5>
+                    <div class="ui-inputgroup">
+                        <p:datePicker id="startDate" value="#{reviewCycleForm.model.startDate}">
+                            <p:ajax event="dateSelect" update="endDate growl" listener="#{reviewCycleForm.updateEndDate}" />
+                        </p:datePicker>
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>End Date</h5>
+                    <div class="ui-inputgroup">
+                        <p:datePicker id="endDate" value="#{reviewCycleForm.model.endDate}" readonlyInput="true" disabled="true" />
+
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-12" style="margin-top: 60px; align-self: flex-end !important;">
+                    <div class="p-grid p-justify-end">
+                        <div class="p-col-2">
+                            <p:commandButton value="Cancel"
+                                             immediate="true"
+                                             action="#{reviewCycleForm.hide}"
+                                             styleClass="ui-button-outlined ui-button-help" />
+                        </div>
+                        <div class="p-col-2">
+                            <!-- 2. REMOVED the nested <p:ajax> tag -->
+                            <p:commandButton value="Save Review cycle"
+                                             process="@form"
+                                             actionListener="#{reviewCycleForm.save}"
+                                             update="@form"
+                                             
+                           />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleTable.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleTable.xhtml
@@ -1,0 +1,129 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+   <ui:define name="content">
+      <h:form id="reviewCycle" enctype="multipart/form-data">
+         <div class="p-grid ">
+            <div class="p-col-12">
+               <div class="card">
+
+                  <p:growl id="messages" showDetail="true" />
+                  <div class="p-d-flex p-jc-between" style="margin: 5px">
+
+                     <div>
+                        <p:commandButton icon="fa fa-search"
+                                         styleClass="p-mr-2 p-mb-2 primary-button" id="searchBtn"
+                                         actionListener="..."
+                                         update="reviewCycleTable" value="Search">
+                        </p:commandButton>
+
+
+
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </div>
+         <div class="p-grid ">
+            <div class="p-col-12">
+               <div class="card">
+                  <p:dataTable id="reviewCycleTable" var="model"
+                               value="#{reviewCycleView.dataModels}" widgetVar="reviewCycleTable"
+                               paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                               paginator="true" lazy="true"
+                               rows="#{reviewCycleView.maximumresultsPerpage}"
+                               emptyMessage="#{reviewCycleView.dataEmptyMessage}"
+                               paginatorPosition="bottom" paginatorAlwaysVisible="false"
+                               rowIndexVar="row" reflow="true" styleClass="TableAlgnment">
+                     <f:facet name="header">
+                        <div class="p-d-flex p-jc-between">
+                           <div>
+                              <span style="font-weight: bold">Review Cycles</span>
+                           </div>
+                           <div>
+                              <p:commandButton value="Add new review cycle"
+                                               actionListener="#{reviewCycleForm.show}">
+                                 <f:setPropertyActionListener value="#{null}"
+                                                              target="#{reviewCycleForm.model}" />
+                                 <p:ajax event="dialogReturn" listener="#{reviewCycleView.reloadFilterReset}" update="reviewCycleTable" />
+                              </p:commandButton>
+                           </div>
+                        </div>
+                     </f:facet>
+                     <p:column width="30" headerText="No.">
+                        <h:outputText value="#{row + 1}" />
+                     </p:column>
+                     <p:column>
+                        <f:facet name="header">
+                           <h:outputText value="Type" />
+                        </f:facet>
+                        <h:outputText value="#{model.type.name()}" />
+                     </p:column>
+                     <p:column>
+                        <f:facet name="header">
+                           <h:outputText value="Start Date" />
+                        </f:facet>
+                        <h:outputText value="#{model.startDate}" />
+                     </p:column>
+                     <p:column>
+                        <f:facet name="header">
+                           <h:outputText value="End date" />
+                        </f:facet>
+                        <h:outputText value="#{model.endDate}" />
+                     </p:column>
+                     <p:column>
+                        <f:facet name="header">
+                           <h:outputText value="Status" />
+                        </f:facet>
+                        <h:outputText value="#{model.status}" />
+                     </p:column>
+
+
+                     <p:column headerText="Action" exportable="false" width="150"
+                               style="text-align: center">
+
+
+                        <p:commandButton icon="fa fa-edit" title="Edit"
+                                         styleClass="ui-button-help" immediate="true"
+                                         actionListener="#{reviewCycleForm.show}">
+                           <f:setPropertyActionListener value="#{model}"
+                                                        target="#{reviewCycleForm.model}" />
+
+                           <p:ajax event="dialogReturn" />
+                        </p:commandButton>
+
+                        <p:commandButton icon="fa fa-times" title="Delete"
+                                         styleClass="ui-button-help"
+                                         actionListener="#{reviewCycleView.deleteClient(model)}"
+                                         update="reviewCycleTable">
+                           <p:confirm header="Confirmation"
+                                      message="Are you sure you want to delete this record?"
+                                      icon="fa fa-question-circle" />
+                        </p:commandButton>
+
+                     </p:column>
+                  </p:dataTable>
+                  <p:blockUI block="reviewCycle" trigger="searchBtn">
+                     <p:graphicImage value="/resources/images/workingicon.png" />
+                  </p:blockUI>
+               </div>
+            </div>
+         </div>
+
+         <p:blockUI block="reviewCycle">
+            <p:graphicImage value="/resources/images/workingicon.png" />
+         </p:blockUI>
+         <p:confirmDialog global="true">
+            <p:commandButton value="Yes" type="button"
+                             styleClass="ui-confirmdialog-yes" icon="fa fa-thumbs-up" />
+            <p:commandButton value="No" type="button"
+                             styleClass="ui-confirmdialog-no" icon="fa fa-thumbs-down" />
+         </p:confirmDialog>
+      </h:form>
+
+   </ui:define>
+</ui:composition>


### PR DESCRIPTION
### Description
This PR introduces the frontend implementation for Review Cycle management in the KPI Tracker system.

The changes include:

ReviewCycleView bean: Backing bean for managing and displaying review cycles in the table view.

ReviewCycleForm bean: Backing bean for handling the review cycle creation and edit dialog.

ReviewCycleTable table UI (reviewCycle.xhtml): Data table to list all review cycles with pagination, edit, and delete actions.

ReviewCycleForm dialog UI (reviewCycleDialog.xhtml): Form for creating or editing review cycles, including type selection, start date, and end date.

ReviewCycleTypeConverter: JSF converter to handle conversion between ReviewCycleType enum values and their string representations for the UI.

Type of change
 

- [ ]  New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

- [ ]  Unit

- [ ]  Integration

### How can this be Tested?
Navigate to the Review Cycles section in the system.

Create a new review cycle using the dialog form:

Select a Review Cycle Type.

Pick a start date and end date.

Save and confirm it appears in the table.

Edit an existing review cycle and verify updates are reflected in the table.

Delete a review cycle and confirm the table updates without requiring a full page refresh.

Confirm that the converter correctly maps enum values between UI and backend.

### Any background context you want to add
The UI uses PrimeFaces components for table, dialog, and date pickers.

The dialog form integrates with the backend ReviewCycleService to persist data.

The table view uses lazy loading to optimize performance for large datasets.