### PR TITLE
Feature global weight backend

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/GlobalWeight.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/GlobalWeight.java
@@ -1,0 +1,45 @@
+package org.pahappa.systems.kpiTracker.models.systemSetup;
+
+import org.sers.webutils.model.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "global_weights")
+public class GlobalWeight extends BaseEntity {
+    private static final long serialVersionUID = 1L;
+    private double mboWeight;
+    private  double OrgFitWeight;
+    private ReviewCycle reviewCycle;
+
+    @Column(name = "mbo_weight")
+    public double getMboWeight() {
+        return mboWeight;
+    }
+
+    public void setMboWeight(double mboWeight) {
+        this.mboWeight = mboWeight;
+    }
+
+    @Column(name = "org_fit_weight")
+    public double getOrgFitWeight() {
+        return OrgFitWeight;
+    }
+
+    public void setOrgFitWeight(double orgFitWeight) {
+        OrgFitWeight = orgFitWeight;
+    }
+
+    @ManyToOne
+    @JoinColumn(
+            name = "review_cycle_Id",
+            nullable = true
+    )
+    public ReviewCycle getReviewCycle() {
+        return reviewCycle;
+    }
+
+    public void setReviewCycle(ReviewCycle reviewCycle) {
+        this.reviewCycle = reviewCycle;
+    }
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/GlobalWeightService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/GlobalWeightService.java
@@ -1,0 +1,7 @@
+package org.pahappa.systems.kpiTracker.core.services;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
+
+public interface GlobalWeightService extends GenericService<GlobalWeight> {
+    GlobalWeight mergeBG(GlobalWeight entity);
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/CustomMigrationService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/CustomMigrationService.java
@@ -24,9 +24,11 @@ public class CustomMigrationService extends MigrationTemplate {
 
     @Autowired
     CustomPermissionRoleMigrations permissionRoleMigrations;
+    @Autowired
+    GlobalWeightMigration globalWeightMigration;
 
     private final List<Class<?>> migrationClasses = Arrays
-            .asList(new Class<?>[]{CustomPermissionRoleMigrations.class});
+            .asList(new Class<?>[]{CustomPermissionRoleMigrations.class, GlobalWeightMigration.class});
 
     public static boolean EXECUTED_MIGRATIONS = false;
 

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/GlobalWeightMigration.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/GlobalWeightMigration.java
@@ -1,0 +1,34 @@
+package org.pahappa.systems.kpiTracker.core.services.impl;
+
+import org.pahappa.systems.kpiTracker.core.services.GlobalWeightService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
+import org.sers.webutils.model.migrations.Migration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+public class GlobalWeightMigration {
+
+    @Autowired
+    private GlobalWeightService globalWeightService;
+
+    @Migration(orderNumber = 2)
+    public void initializeDefaultGlobalWeight1() {
+        System.out.println(">>>> Running GlobalWeight migration");
+        createIfNotExists(60, 40);
+    }
+
+
+    private void createIfNotExists(double mboWeight, double orgFitWeight) {
+        if (globalWeightService.getAllInstances().isEmpty()) {
+            GlobalWeight weight = new GlobalWeight();
+            weight.setMboWeight(mboWeight);
+            weight.setOrgFitWeight(orgFitWeight);
+            globalWeightService.mergeBG(weight);
+        }
+    }
+
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/GlobalWeightServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/GlobalWeightServiceImpl.java
@@ -1,0 +1,26 @@
+package org.pahappa.systems.kpiTracker.core.services.impl;
+
+import org.pahappa.systems.kpiTracker.core.services.GlobalWeightService;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
+import org.pahappa.systems.kpiTracker.utils.Validate;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.exception.ValidationFailedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class GlobalWeightServiceImpl extends GenericServiceImpl<GlobalWeight> implements GlobalWeightService {
+    @Override
+    public GlobalWeight saveInstance(GlobalWeight entityInstance) throws ValidationFailedException, OperationFailedException {
+        Validate.notNull(entityInstance, "Missing details");
+        return merge(entityInstance);
+    }
+
+    @Override
+    public boolean isDeletable(GlobalWeight instance) throws OperationFailedException {
+        return true;
+    }
+
+}


### PR DESCRIPTION
### Description
Added a new GlobalWeight feature with backend support. This includes:

Model: Created GlobalWeight entity with mboWeight and orgFitWeight fields.

Service: Added GlobalWeightService interface for business logic.

Implementation: Implemented GlobalWeightServiceImpl extending GenericServiceImpl.

Migration: Added GlobalWeightMigration class to automatically create default global weight values (60% MBO, 40% Org Fit) if none exist in the system.

### Type of change

- [ ] New feature (non-breaking change which adds functionality)

How Has This Been Tested? 

- [ ] Unit

### How can this be Tested?

Start the application.

Verify in the database that the global_weight table has been created.

On first run, check that a default record exists with MBO Weight = 60 and Org Fit Weight = 40.

If the table already contains records, migration should not add duplicates.