### PR TITLE
Feature global weight frontend

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/GlobalWeightForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/GlobalWeightForm.java
@@ -1,0 +1,46 @@
+package org.pahappa.systems.kpiTracker.views.dialogs.systemSetup;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.GlobalWeightService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+
+@ManagedBean(name = "globalWeightsForm")
+@Getter
+@Setter
+@SessionScoped
+public class GlobalWeightForm extends DialogForm<GlobalWeight> {
+    private static final long serialVersionUID = 1L;
+
+    private GlobalWeightService globalWeightService;
+
+    public GlobalWeightForm() {
+        super(HyperLinks.GLOBAL_WEIGHT_DIALOG, 800, 700);
+    }
+
+    @PostConstruct
+    public void init() {
+        globalWeightService = ApplicationContextProvider.getBean(GlobalWeightService.class);
+    }
+
+    @Override
+    public void persist() throws Exception {
+        globalWeightService.saveInstance(super.model);
+    }
+
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new GlobalWeight();
+    }
+
+
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/GlobalWeightView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/GlobalWeightView.java
@@ -1,0 +1,75 @@
+package org.pahappa.systems.kpiTracker.views.systemSetup;
+
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+
+import org.pahappa.systems.kpiTracker.core.services.GlobalWeightService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.sers.webutils.client.views.presenters.PaginatedTableView;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.List;
+import java.util.Map;
+
+@ManagedBean(name = "globalWeightView")
+@Setter
+@Getter
+@SessionScoped
+public class GlobalWeightView extends PaginatedTableView<GlobalWeight, GlobalWeightService, GlobalWeightService> {
+    private GlobalWeightService globalWeightService;
+    private Search search;
+
+
+    @PostConstruct
+    public void init(){
+        globalWeightService = ApplicationContextProvider.getBean(GlobalWeightService.class);
+
+        reloadFilterReset();
+    }
+    @Override
+    public void reloadFromDB(int i, int i1, Map<String, Object> map) throws Exception {
+        super.setDataModels(globalWeightService.getInstances(new Search().addFilterEqual("recordStatus", RecordStatus.ACTIVE),i,i1));
+    }
+
+    @Override
+    public List<ExcelReport> getExcelReportModels() {
+        return null;
+    }
+
+    @Override
+    public String getFileName() {
+        return null;
+    }
+
+    @Override
+    public List load(int i, int i1, Map map, Map map1) {
+        return null;
+    }
+
+    @Override
+    public void reloadFilterReset(){
+        super.setTotalRecords(globalWeightService.countInstances(new Search()));
+        try{
+            super.reloadFilterReset();
+        }catch(Exception e){
+            UiUtils.ComposeFailure("Error",e.getLocalizedMessage());
+        }
+
+    }
+
+    public void deleteClient(GlobalWeight globalWeight) {
+        try {
+            globalWeightService.deleteInstance(globalWeight);
+        } catch (OperationFailedException e) {
+            UiUtils.ComposeFailure("Delete Failed", e.getLocalizedMessage());
+        }
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
+++ b/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
@@ -44,6 +44,9 @@
 		<mapping class="org.pahappa.systems.kpiTracker.models.MailSetting"/>
 		<mapping class="org.pahappa.systems.kpiTracker.models.settings.ApplicationSettings"/>
 		<mapping class="org.pahappa.systems.kpiTracker.models.demo.MyDemo" />
+		<mapping class="org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight" />
+		<mapping class="org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory" />
+		<mapping class="org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle" />
 		
 	</session-factory>
 </hibernate-configuration>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeghtTable.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeghtTable.xhtml
@@ -1,0 +1,122 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+   <ui:define name="content">
+      <h:form id="globalWeightView" enctype="multipart/form-data">
+         <div class="p-grid ">
+            <div class="p-col-12">
+               <div class="card">
+                  <p:growl id="messages" showDetail="true" />
+                  <div class="p-d-flex p-jc-between" style="margin: 5px">
+
+                     <div>
+                        <p:commandButton icon="fa fa-search"
+                                         styleClass="p-mr-2 p-mb-2 primary-button" id="searchBtn"
+                                         actionListener="#{globalWeightView.reloadFilterReset()}"
+                                         update="globalWeightView" value="Search">
+                        </p:commandButton>
+
+                        <p:commandButton value="Configure new weight"
+                                         actionListener="#{globalWeightsForm.show}">
+                           <f:setPropertyActionListener value="#{null}"
+                                                        target="#{globalWeightsForm.model}" />
+                           <p:ajax event="dialogReturn" listener="#{globalWeightView.reloadFilterReset}" update="globalWeightTable" />
+                        </p:commandButton>
+
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </div>
+         <div class="p-grid ">
+            <div class="p-col-12">
+               <div class="card">
+                  <p:dataTable id="globalWeightTable" var="model"
+                               value="#{globalWeightView.dataModels}" widgetVar="globalWeightTable"
+                               paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                               paginator="true" lazy="true"
+                               rows="#{globalWeightView.maximumresultsPerpage}"
+                               emptyMessage="#{globalWeightView.dataEmptyMessage}"
+                               paginatorPosition="bottom" paginatorAlwaysVisible="false"
+                               rowIndexVar="row" reflow="true" styleClass="TableAlgnment">
+                     <f:facet name="header">
+                        <div class="p-d-flex p-jc-between">
+                           <div>
+                              <span style="font-weight: bold">Roles</span>
+                           </div>
+
+                        </div>
+                     </f:facet>
+                     <p:column width="30" headerText="No.">
+                        <h:outputText value="#{row + 1}" />
+                     </p:column>
+                     <p:column>
+                        <f:facet name="header">
+                           <h:outputText value="Business goal weight" />
+                        </f:facet>
+                        <h:outputText value="#{model.mboWeight}" />
+                     </p:column>
+                     <p:column>
+                        <f:facet name="header">
+                           <h:outputText value="Org fit weight" />
+                        </f:facet>
+                        <h:outputText value="#{model.orgFitWeight}" />
+                     </p:column>
+                     <p:column>
+                        <f:facet name="header">
+                           <h:outputText value="Review cycle id" />
+                        </f:facet>
+                        <h:outputText value="#{model.reviewCycle.id}" />
+                     </p:column>
+
+
+                     <p:column headerText="Action" exportable="false" width="150"
+                               style="text-align: center">
+
+
+                        <p:commandButton icon="fa fa-edit" title="Edit"
+                                         styleClass="ui-button-help" immediate="true"
+                                         actionListener="#{globalWeightsForm.show}">
+                           <f:setPropertyActionListener value="#{model}"
+                                                        target="#{globalWeightsForm.model}" />
+
+                           <p:ajax event="dialogReturn" update="globalWeightTable" />
+                        </p:commandButton>
+
+                        <p:commandButton icon="fa fa-times" title="Delete"
+                                         styleClass="ui-button-help" immediate="true"
+                                         actionListener="#{globalWeightView.deleteClient(model)}" >
+                           <p:confirm header="Confirmation"
+                                      message="Are you sure you want to delete this record?"
+                                      icon="fa fa-question-circle" />
+
+                           <p:ajax event="dialogReturn" update="globalWeightTable" />
+                        </p:commandButton>
+
+
+                     </p:column>
+                  </p:dataTable>
+                  <p:blockUI block="globalWeightView" trigger="searchBtn">
+                     <p:graphicImage value="/resources/images/workingicon.png" />
+                  </p:blockUI>
+               </div>
+            </div>
+         </div>
+
+         <p:blockUI block="globalWeightView">
+            <p:graphicImage value="/resources/images/workingicon.png" />
+         </p:blockUI>
+         <p:confirmDialog global="true">
+            <p:commandButton value="Yes" type="button"
+                             styleClass="ui-confirmdialog-yes" icon="fa fa-thumbs-up" />
+            <p:commandButton value="No" type="button"
+                             styleClass="ui-confirmdialog-no" icon="fa fa-thumbs-down" />
+         </p:confirmDialog>
+      </h:form>
+
+   </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeightForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeightForm.xhtml
@@ -1,0 +1,63 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/dialog-template.xhtml">
+    <ui:define name="head">
+        <style type="text/css">
+            .capitalized {
+                text-transform: capitalize;
+            }
+        </style>
+    </ui:define>
+    <ui:define name="content">
+        <title>Manage Global weight </title>
+        <h:form id="globalWeightDialog" styleClass="card" style="height: 450px;">
+            <div class="p-grid ui-fluid">
+
+                <!-- Business Goal Weight -->
+                <div class="p-col-12 p-md-3">
+                    <h5>Business goal weight</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputText value="#{globalWeightsForm.model.mboWeight}" required="true"
+                        />
+                    </div>
+                </div>
+
+                <!-- Organizational Fit Weight -->
+                <div class="p-col-12 p-md-3">
+                    <h5>Organizational fit weight</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputText value="#{globalWeightsForm.model.orgFitWeight}" required="true" />
+                    </div>
+                </div>
+
+                <!-- Buttons -->
+                <div class="p-col-12" style="margin-top: 60px;">
+                    <div class="p-grid p-justify-center p-align-center">
+                        <div class="p-col-12 p-md-3">
+                            <p:commandButton value="Cancel"
+                                             validateClient="false"
+                                             process="@this"
+                                             action="#{globalWeightsForm.hide}"
+                                             styleClass="ui-button-outlined ui-button-help"
+                                             style="width: 100%;" />
+                        </div>
+                        <div class="p-col-12 p-md-3">
+                            <p:commandButton value="Save"
+                                             process="@form"
+                                             actionListener="#{globalWeightsForm.persist}"
+                                             update="@form"
+                                             validateClient="true"
+                                             style="width: 100%;" />
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </h:form>
+
+
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
### Description
Implemented frontend components for managing Global Weight records.
This includes:

- Managed Beans:

Bean for the Global Weight table view.

Bean for the Global Weight dialog/form view.

User Interfaces (XHTML):

Table UI to list existing Global Weight records with pagination and actions (edit/delete).

Dialog UI to create or edit Global Weight records with form validation.

### Type of change



 

- [ ] New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

- [ ] Integration


### How can this be Tested?

Navigate to the Global Weight Management page in the application.

Confirm that the table correctly lists all existing global weight records.

Click the Add/Edit button to open the dialog form.

Fill in or update MBO Weight and Org Fit Weight values, then save.

Verify that the changes are reflected in the table without a page reload.

Use the delete action to remove a record and confirm the table updates accordingly.