### PR TITLE
Feature Org Fit Category  backend

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/OrgFitCategory.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/OrgFitCategory.java
@@ -1,0 +1,54 @@
+package org.pahappa.systems.kpiTracker.models.systemSetup;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.OrgFitCategoryType;
+import org.sers.webutils.model.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "organization_fit_categories")
+public class OrgFitCategory extends BaseEntity {
+    private String name;
+    private String description;
+    private double weight;
+    private OrgFitCategoryType type;
+
+    @Column(nullable = false)
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+    @Column(nullable = true)
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    @Column(
+            name = "org_fit_category_weight",
+            nullable = true)
+    public double getWeight() {
+        return weight;
+    }
+
+    public void setWeight(double weight) {
+        this.weight = weight;
+    }
+
+    @Column(
+            name = "org_fit_category_type",
+            updatable = false)
+    @Enumerated(EnumType.STRING)
+    public OrgFitCategoryType getType() {
+        return type;
+    }
+
+    public void setType(OrgFitCategoryType type) {
+        this.type = type;
+    }
+}

--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/enums/OrgFitCategoryType.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/enums/OrgFitCategoryType.java
@@ -1,0 +1,8 @@
+package org.pahappa.systems.kpiTracker.models.systemSetup.enums;
+
+public enum OrgFitCategoryType {
+    TEAM_RATING,
+    COMPANY_VALUES,
+    KEEPER_TEST
+}
+

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/OrgFitCategoryService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/OrgFitCategoryService.java
@@ -1,0 +1,7 @@
+package org.pahappa.systems.kpiTracker.core.services;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+
+public interface OrgFitCategoryService extends GenericService<OrgFitCategory> {
+    Object getObjectById(String var1);
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/OrgFitCategoryServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/OrgFitCategoryServiceImpl.java
@@ -1,0 +1,32 @@
+package org.pahappa.systems.kpiTracker.core.services.impl;
+
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryService;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+import org.pahappa.systems.kpiTracker.utils.Validate;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.exception.ValidationFailedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class OrgFitCategoryServiceImpl extends GenericServiceImpl<OrgFitCategory> implements OrgFitCategoryService {
+
+    @Override
+    public OrgFitCategory saveInstance(OrgFitCategory entityInstance) throws ValidationFailedException, OperationFailedException {
+        Validate.notNull(entityInstance, "Missing details");
+        return save(entityInstance);
+    }
+
+    @Override
+    public boolean isDeletable(OrgFitCategory instance) throws OperationFailedException {
+        return true;
+    }
+
+
+
+    public Object getObjectById(String id) {
+        return super.getInstanceByID(id);
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
@@ -15,4 +15,9 @@ public class HyperLinks {
     public static final String LOGIN_FORM = "/ExternalViews/Login.xhtml?faces-redirect=true";
 
     public static final String NAME_DIALOG = "/pages/registerUser/DemoDialog.xhtml";
+    public static final String GLOBAL_WEIGHT_DIALOG = "/pages/systemSetup/GlobalWeightForm.xhtml";
+    public static final String GLOBAL_WEIGHT_TABLE = "/pages/systemSetup/GlobalWeghtTable.xhtml?faces-redirect=true";
+    public static final String ORG_FIT_CATEGORY_DIALOG = "/pages/systemSetup/OrgFitCategoryForm.xhtml";
+    public static final String REVIEW_CYCLE_DIALOG = "/pages/systemSetup/ReviewCycleForm.xhtml";
+
 }


### PR DESCRIPTION
### Description
Implemented the Org Fit Category feature in the backend.
This includes:

- Model:

OrgFitCategory entity to represent organization fit categories.

- Service:

Interface for managing OrgFitCategory records.

- Implementation:

Concrete service implementation extending the generic service layer to handle CRUD operations.

- Enum:

Enum for defining OrgFitCategoryType values.

- Hyperlinks Update:

Added new hyperlink constant(s) for Org Fit Category navigation and view references.

###  Type of change


- [ ]  New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

 

- [ ] Unit tests

- [ ]  Manual testing via service calls and application UI integration

### How to Test

Use the service layer or REST endpoints to create a new Org Fit Category with a valid type.

Retrieve all Org Fit Categories and confirm correct persistence.

Update an existing category and verify changes.

Delete a category and ensure it no longer appears in retrieval results.

Check that the updated Hyperlinks.java provides correct navigation paths in the UI.

