### PR TITLE
Feauture Org Fit Category frontend

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/OrgFitCategoryForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/OrgFitCategoryForm.java
@@ -1,0 +1,41 @@
+package org.pahappa.systems.kpiTracker.views.dialogs.systemSetup;
+
+
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+
+@ManagedBean(name = "orgFitCategoryForm")
+@SessionScoped
+public class OrgFitCategoryForm extends DialogForm<OrgFitCategory> {
+    private OrgFitCategoryService orgFitCategoryService;
+
+    public OrgFitCategoryForm() {
+        super(HyperLinks.ORG_FIT_CATEGORY_DIALOG, 700, 800);
+    }
+
+    @PostConstruct
+    public void init() {
+        this.orgFitCategoryService = ApplicationContextProvider.getBean(OrgFitCategoryService.class);
+
+    }
+
+    @Override
+    public void persist() throws Exception {
+
+        orgFitCategoryService.saveInstance(super.model);
+    }
+
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new OrgFitCategory();
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/OrgFitCategoryView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/OrgFitCategoryView.java
@@ -1,0 +1,75 @@
+package org.pahappa.systems.kpiTracker.views.systemSetup;
+
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.sers.webutils.client.views.presenters.PaginatedTableView;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.List;
+import java.util.Map;
+
+@ManagedBean(name = "orgFitCategoryView")
+@Setter
+@Getter
+@SessionScoped
+public class OrgFitCategoryView extends PaginatedTableView<OrgFitCategory, OrgFitCategoryService,OrgFitCategoryService> {
+    private OrgFitCategoryService orgFitService;
+    private Search search;
+
+
+    @PostConstruct
+    public void init(){
+        orgFitService = ApplicationContextProvider.getBean(OrgFitCategoryService.class);
+        reloadFilterReset();
+    }
+    @Override
+    public void reloadFromDB(int i, int i1, Map<String, Object> map) throws Exception {
+        super.setDataModels(orgFitService.getInstances(new Search().addFilterEqual("recordStatus", RecordStatus.ACTIVE),i,i1));
+    }
+
+    @Override
+    public List<ExcelReport> getExcelReportModels() {
+        return null;
+    }
+
+    @Override
+    public String getFileName() {
+        return null;
+    }
+
+    @Override
+    public List load(int i, int i1, Map map, Map map1) {
+        return null;
+    }
+
+    @Override
+    public void reloadFilterReset(){
+        super.setTotalRecords(orgFitService.countInstances(new Search()));
+        try{
+            super.reloadFilterReset();
+        }catch(Exception e){
+            UiUtils.ComposeFailure("Error",e.getLocalizedMessage());
+        }
+
+    }
+
+    public void deleteClient(OrgFitCategory orgFitCategory) {
+        try {
+            orgFitService.deleteInstance(orgFitCategory);
+        } catch (OperationFailedException e) {
+            UiUtils.ComposeFailure("Delete Failed", e.getLocalizedMessage());
+        }
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
@@ -42,6 +42,17 @@
                         <p:menuitem id="demo" value="Demo" icon="fa fa-wrench"
                                     outcome="/pages/registerUser/RegisterUser"/>
                     </p:submenu>
+
+                    <p:submenu id="systemSetup" label="System Setup" icon="pi pi-fw pi-cog">
+                        <p:menuitem id="globalWeight" value="Global weight config" icon="fa fa-wrench"
+                                    outcome="/pages/systemSetup/GlobalWeghtTable"/>
+
+                        <p:menuitem id="orgfit" value="Org Fit Categories" icon="fa fa-wrench"
+                                    outcome="/pages/systemSetup/OrgFitCategoryTable"/>
+                        <p:menuitem id="reviewCycle" value="ReviewCycles" icon="fa fa-wrench"
+                                    outcome="/pages/systemSetup/ReviewCycleTable"/>
+                    </p:submenu>
+
                     <p:menuitem id="logout" value="Logout" icon="fa fa-fw fa-sign-out"
                                 url="#{request.contextPath}/ServiceLogout"/>
                 </pc:menu>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryForm.xhtml
@@ -1,0 +1,59 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/dialog-template.xhtml">
+    <ui:define name="head">
+        <style type="text/css">
+            .capitalized {
+                text-transform: capitalize;
+            }
+        </style>
+    </ui:define>
+    <ui:define name="content">
+        <title>Add department </title>
+        <h:form id="departmentDialog" style="height: 450px" styleClass="card">
+            <div class="p-grid ui-fluid" style="display:flex">
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Name</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputText value="#{orgFitCategoryForm.model.name}" required="true" />
+                    </div>
+                </div>
+
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Description</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputText value="#{orgFitCategoryForm.model.description}" required="true" />
+                    </div>
+                </div>
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Weight</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputText value="#{orgFitCategoryForm.model.weight}" required="true" />
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-12" style="margin-top: 60px; align-self: flex-end !important;">
+                    <div class="p-grid p-justify-end">
+                        <div class="p-col-2">
+                            <p:commandButton value="Cancel"
+                                             validateClient="false"
+                                             process="@this"
+                                             action="#{orgFitCategoryForm.hide}"
+                                             styleClass="ui-button-outlined ui-button-help" />
+                        </div>
+                        <div class="p-col-2" >
+                            <p:commandButton value="Save User"
+                                             process="@form"
+                                             actionListener="#{orgFitCategoryForm.save}"
+                                             update="@form" validateClient="true" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryTable.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryTable.xhtml
@@ -1,0 +1,131 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+    <ui:define name="content">
+        <h:form id="orgFitView" enctype="multipart/form-data">
+            <div class="p-grid ">
+                <div class="p-col-12">
+                    <div class="card">
+
+                        <p:growl id="messages" showDetail="true" />
+                        <div class="p-d-flex p-jc-between" style="margin: 5px">
+
+                            <div>
+                                <p:commandButton icon="fa fa-search"
+                                                 styleClass="p-mr-2 p-mb-2 primary-button" id="searchBtn"
+                                                 actionListener="..."
+                                                 update="orgFitTable" value="Search">
+                                </p:commandButton>
+
+                                <p:commandButton value="Configure new weight"
+                                                 actionListener="#{orgFitCategoryForm.show}">
+                                    <f:setPropertyActionListener value="#{null}"
+                                                                 target="#{orgFitCategoryForm.model}" />
+                                    <p:ajax event="dialogReturn" listener="#{orgFitCategoryView.reloadFilterReset}" update="orgFitView" />
+                                </p:commandButton>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="p-grid ">
+                <div class="p-col-12">
+                    <div class="card">
+                        <p:dataTable id="orgFitTable" var="model"
+                                     value="#{orgFitCategoryView.dataModels}" widgetVar="orgFitTable"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                                     paginator="true" lazy="true"
+                                     rows="#{orgFitCategoryView.maximumresultsPerpage}"
+                                     emptyMessage="#{orgFitCategoryView.dataEmptyMessage}"
+                                     paginatorPosition="bottom" paginatorAlwaysVisible="false"
+                                     rowIndexVar="row" reflow="true" styleClass="TableAlgnment">
+                            <f:facet name="header">
+                                <div class="p-d-flex p-jc-between">
+                                    <div>
+                                        <span style="font-weight: bold">Roles</span>
+                                    </div>
+                                    <div>
+                                        <p:commandButton value="Add Role" process="@this"
+                                                         styleClass="ui-button-help" immediate="true"
+                                                         actionListener="#{myDialogForm.show}">
+                                            <f:setPropertyActionListener value="#{null}"
+                                                                         target="#{myDialogForm.model}" />
+                                            <p:ajax event="dialogReturn" listener="#{orgFitCategoryView.reloadFilterReset}" update="orgFitTable" />
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+                            <p:column width="30" headerText="No.">
+                                <h:outputText value="#{row + 1}" />
+                            </p:column>
+                            <p:column>
+                                <f:facet name="header">
+                                    <h:outputText value="Name" />
+                                </f:facet>
+                                <h:outputText value="#{model.name}" />
+                            </p:column>
+                            <p:column>
+                                <f:facet name="header">
+                                    <h:outputText value="Weight" />
+                                </f:facet>
+                                <h:outputText value="#{model.weight}" />
+                            </p:column>
+                            <p:column>
+                                <f:facet name="header">
+                                    <h:outputText value="Description" />
+                                </f:facet>
+                                <h:outputText value="#{model.description}" />
+                            </p:column>
+
+
+                            <p:column headerText="Action" exportable="false" width="150"
+                                      style="text-align: center">
+
+
+                                <p:commandButton icon="fa fa-edit" title="Edit"
+                                                 styleClass="ui-button-help" immediate="true"
+                                                 actionListener="#{orgFitCategoryForm.show}">
+                                    <f:setPropertyActionListener value="#{model}"
+                                                                 target="#{orgFitCategoryForm.model}" />
+
+                                    <p:ajax event="dialogReturn" />
+                                </p:commandButton>
+
+                                <p:commandButton icon="fa fa-times" title="Delete"
+                                                 styleClass="ui-button-help" immediate="true"
+                                                 actionListener="#{orgFitCategoryView.deleteClient(model)}" >
+                                    <p:confirm header="Confirmation"
+                                               message="Are you sure you want to delete this record?"
+                                               icon="fa fa-question-circle" />
+
+                                    <p:ajax event="dialogReturn" />
+                                </p:commandButton>
+
+
+                            </p:column>
+                        </p:dataTable>
+                        <p:blockUI block="orgFitView" trigger="searchBtn">
+                            <p:graphicImage value="/resources/images/workingicon.png" />
+                        </p:blockUI>
+                    </div>
+                </div>
+            </div>
+
+            <p:blockUI block="orgFitView">
+                <p:graphicImage value="/resources/images/workingicon.png" />
+            </p:blockUI>
+            <p:confirmDialog global="true">
+                <p:commandButton value="Yes" type="button"
+                                 styleClass="ui-confirmdialog-yes" icon="fa fa-thumbs-up" />
+                <p:commandButton value="No" type="button"
+                                 styleClass="ui-confirmdialog-no" icon="fa fa-thumbs-down" />
+            </p:confirmDialog>
+        </h:form>
+
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
### Description
Implemented the Org Fit Category frontend components.
This includes:

- Managed Beans:

Bean for the Org Fit Category table.

Bean for the Org Fit Category dialog form.

- User Interfaces (XHTML):

Page for displaying the Org Fit Category table with CRUD actions.

Dialog form for creating and editing Org Fit Categories.

- Sidebar Update:

Added navigation link to the Org Fit Category table page in the sidebar.

### Type of change 

- [ ] New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

-  Manual testing in the UI:

Verified table loads correctly with data from the backend.

Verified dialog form opens, saves, and updates records correctly.

Verified delete action removes entries and refreshes the table.

Verified sidebar navigation works and highlights correctly.

### How to Test

Navigate to the Org Fit Category table via the updated sidebar.

Use the "Add New" button to open the dialog and create a new category.

Edit an existing category via the table’s edit action.

Delete a category and confirm the table updates immediately.

Check that navigation to the page via the sidebar works without errors.