### PR TITLE
Styling the ui for review cycle

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/ReviewCycleForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/ReviewCycleForm.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.pahappa.systems.kpiTracker.core.services.impl.ReviewCycleService;
 import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.ReviewCycleStatus;
 import org.pahappa.systems.kpiTracker.models.systemSetup.enums.ReviewCycleType;
 import org.pahappa.systems.kpiTracker.security.HyperLinks;
 import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
@@ -29,15 +30,17 @@ public class ReviewCycleForm extends DialogForm<ReviewCycle> {
     private static final long serialVersionUID = 1L;
     private ReviewCycleService reviewCycleService;
     private List<ReviewCycleType> reviewCycleTypes = new ArrayList<>();
+    private List<ReviewCycleStatus> reviewCycleStatusList = new ArrayList<>();
 
     public ReviewCycleForm() {
-        super(HyperLinks.REVIEW_CYCLE_DIALOG, 700, 800);
+        super(HyperLinks.REVIEW_CYCLE_DIALOG, 500, 400);
     }
 
     @PostConstruct
     public void init() {
         this.reviewCycleService = ApplicationContextProvider.getBean(ReviewCycleService.class);
         this.reviewCycleTypes = Arrays.asList(ReviewCycleType.values());
+        this.reviewCycleStatusList = Arrays.asList(ReviewCycleStatus.values());
     }
 
     @Override
@@ -54,6 +57,7 @@ public class ReviewCycleForm extends DialogForm<ReviewCycle> {
         model.setEndDate(calculateEndDate(model.getType(), model.getStartDate()));
 
         reviewCycleService.saveInstance(super.model);
+
     }
 
 

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
@@ -43,14 +43,10 @@
                                     outcome="/pages/registerUser/RegisterUser"/>
                     </p:submenu>
 
-                    <p:submenu id="systemSetup" label="System Setup" icon="pi pi-fw pi-cog">
-                        <p:menuitem id="globalWeight" value="Global weight config" icon="fa fa-wrench"
-                                    outcome="/pages/systemSetup/GlobalWeghtTable"/>
-
-                        <p:menuitem id="orgfit" value="Org Fit Categories" icon="fa fa-wrench"
-                                    outcome="/pages/systemSetup/OrgFitCategoryTable"/>
-                        <p:menuitem id="reviewCycle" value="ReviewCycles" icon="fa fa-wrench"
-                                    outcome="/pages/systemSetup/ReviewCycleTable"/>
+                    <p:submenu label="System Setup" icon="pi pi-fw pi-cog">
+                        <p:menuitem value="Global weight config" icon="pi pi-fw pi-sliders-h" outcome="/pages/systemSetup/GlobalWeightTable" />
+                        <p:menuitem value="Org Fit Categories" icon="pi pi-fw pi-list" outcome="/pages/systemSetup/OrgFitCategoryTable" />
+                        <p:menuitem value="Review Cycles" icon="pi pi-fw pi-refresh" outcome="/pages/systemSetup/ReviewCycleTable" />
                     </p:submenu>
 
                     <p:menuitem id="logout" value="Logout" icon="fa fa-fw fa-sign-out"

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleForm.xhtml
@@ -5,66 +5,61 @@
                 xmlns:p="http://primefaces.org/ui"
                 template="/pages/californiatemplate/dialog-template.xhtml">
 
-    <ui:define name="head">
-        <style type="text/css">
-            .capitalized { text-transform: capitalize; }
-        </style>
-    </ui:define>
-
     <ui:define name="content">
-        <title>Add Review Cycle</title>
-        <h:form id="reviewCycleDialog" style="height: 450px" styleClass="card">
+        <h:form id="reviewCycleDialogForm">
 
-            <!-- 1. ADDED GROWL TO DISPLAY MESSAGES -->
             <p:growl id="growl" showDetail="true" life="4000" />
 
-            <div class="p-grid ui-fluid" style="display:flex; flex-wrap: wrap;">
-                <div class="ui-col-12 ui-md-6">
-                    <h5>Type</h5>
-                    <div class="ui-inputgroup">
-                        <p:selectOneMenu value="#{reviewCycleForm.model.type}">
-                            <f:selectItems value="#{reviewCycleForm.reviewCycleTypes}" />
-                            <p:ajax event="change" update="endDate growl" listener="#{reviewCycleForm.updateEndDate}" />
-                        </p:selectOneMenu>
-                    </div>
+            <h3 class="p-m-4">Add Review Cycle</h3>
+
+            <div class="ui-fluid formgrid grid p-m-4">
+
+                <!-- Type -->
+                <div class="field col-12 p-m-4">
+
+                    <p:selectOneMenu id="type" value="#{reviewCycleForm.model.type}">
+                        <f:selectItem itemLabel="Select Type" itemValue="#{null}" noSelectionOption="true"/>
+                        <f:selectItems value="#{reviewCycleForm.reviewCycleTypes}" />
+                        <p:ajax event="change" update="endDate growl" listener="#{reviewCycleForm.updateEndDate}" />
+                    </p:selectOneMenu>
                 </div>
 
-                <div class="ui-col-12 ui-md-6">
-                    <h5>Start day</h5>
-                    <div class="ui-inputgroup">
-                        <p:datePicker id="startDate" value="#{reviewCycleForm.model.startDate}">
-                            <p:ajax event="dateSelect" update="endDate growl" listener="#{reviewCycleForm.updateEndDate}" />
-                        </p:datePicker>
-                    </div>
+                <!-- Start Date -->
+                <div class="field col-12 md:col-6 p-m-4">
+
+                    <p:datePicker id="startDate" value="#{reviewCycleForm.model.startDate}" placeholder="Start Date" showIcon="true">
+                        <p:ajax event="dateSelect" update="endDate growl" listener="#{reviewCycleForm.updateEndDate}" />
+                    </p:datePicker>
                 </div>
 
-                <div class="ui-col-12 ui-md-6">
-                    <h5>End Date</h5>
-                    <div class="ui-inputgroup">
-                        <p:datePicker id="endDate" value="#{reviewCycleForm.model.endDate}" readonlyInput="true" disabled="true" />
-
-                    </div>
+                <!-- End Date -->
+                <div class="field col-12 md:col-6 p-m-4">
+                    <p:datePicker id="endDate" value="#{reviewCycleForm.model.endDate}" placeholder="End Date" readonlyInput="true" disabled="true" showIcon="true" />
                 </div>
 
-                <div class="ui-col-12 ui-md-12" style="margin-top: 60px; align-self: flex-end !important;">
-                    <div class="p-grid p-justify-end">
-                        <div class="p-col-2">
-                            <p:commandButton value="Cancel"
-                                             immediate="true"
-                                             action="#{reviewCycleForm.hide}"
-                                             styleClass="ui-button-outlined ui-button-help" />
-                        </div>
-                        <div class="p-col-2">
-                            <!-- 2. REMOVED the nested <p:ajax> tag -->
-                            <p:commandButton value="Save Review cycle"
-                                             process="@form"
-                                             actionListener="#{reviewCycleForm.save}"
-                                             update="@form"
-                                             
-                           />
-                        </div>
-                    </div>
+                <!-- Status -->
+                <div class="field col-12 p-m-4">
+
+                    <p:selectOneMenu id="status" value="#{reviewCycleForm.model.status}">
+                        <f:selectItem itemLabel="Select Status" itemValue="#{null}" noSelectionOption="true"/>
+                        <f:selectItems value="#{reviewCycleForm.reviewCycleStatusList}" />
+                    </p:selectOneMenu>
                 </div>
+
+                <!-- Buttons -->
+                <div class="field col-12 p-d-flex p-jc-between">
+                    <p:commandButton value="Cancel"
+                                     immediate="true"
+                                     action="#{reviewCycleForm.hide}"
+                                     styleClass="ui-button-danger p-mx-5" />
+
+                    <p:commandButton value="Save"
+                                     process="@form"
+                                     actionListener="#{reviewCycleForm.save}"
+                                     update="@form growl"
+                                     styleClass="ui-button-primary p-mx-5" />
+                </div>
+
             </div>
         </h:form>
     </ui:define>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleTable.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/ReviewCycleTable.xhtml
@@ -7,27 +7,7 @@
 
    <ui:define name="content">
       <h:form id="reviewCycle" enctype="multipart/form-data">
-         <div class="p-grid ">
-            <div class="p-col-12">
-               <div class="card">
 
-                  <p:growl id="messages" showDetail="true" />
-                  <div class="p-d-flex p-jc-between" style="margin: 5px">
-
-                     <div>
-                        <p:commandButton icon="fa fa-search"
-                                         styleClass="p-mr-2 p-mb-2 primary-button" id="searchBtn"
-                                         actionListener="..."
-                                         update="reviewCycleTable" value="Search">
-                        </p:commandButton>
-
-
-
-                     </div>
-                  </div>
-               </div>
-            </div>
-         </div>
          <div class="p-grid ">
             <div class="p-col-12">
                <div class="card">
@@ -46,7 +26,9 @@
                            </div>
                            <div>
                               <p:commandButton value="Add new review cycle"
-                                               actionListener="#{reviewCycleForm.show}">
+                                               actionListener="#{reviewCycleForm.show}"
+                              styleClass="ui-button-success"
+                              >
                                  <f:setPropertyActionListener value="#{null}"
                                                               target="#{reviewCycleForm.model}" />
                                  <p:ajax event="dialogReturn" listener="#{reviewCycleView.reloadFilterReset}" update="reviewCycleTable" />
@@ -86,9 +68,9 @@
                      <p:column headerText="Action" exportable="false" width="150"
                                style="text-align: center">
 
-
                         <p:commandButton icon="fa fa-edit" title="Edit"
-                                         styleClass="ui-button-help" immediate="true"
+                                         styleClass="ui-button-text-icon-primary" immediate="true"
+                                         style="margin-right: 5px"
                                          actionListener="#{reviewCycleForm.show}">
                            <f:setPropertyActionListener value="#{model}"
                                                         target="#{reviewCycleForm.model}" />
@@ -96,20 +78,18 @@
                            <p:ajax event="dialogReturn" />
                         </p:commandButton>
 
-                        <p:commandButton icon="fa fa-times" title="Delete"
-                                         styleClass="ui-button-help"
+                        <p:commandButton icon="fa fa-trash" title="Delete"
+                                         styleClass="ui-button-danger"
                                          actionListener="#{reviewCycleView.deleteClient(model)}"
                                          update="reviewCycleTable">
-                           <p:confirm header="Confirmation"
-                                      message="Are you sure you want to delete this record?"
-                                      icon="fa fa-question-circle" />
+                           <p:confirm header="Delete review cycle"
+                                      message="Are you sure you want to delete this review cycle"
+                                       />
                         </p:commandButton>
 
                      </p:column>
                   </p:dataTable>
-                  <p:blockUI block="reviewCycle" trigger="searchBtn">
-                     <p:graphicImage value="/resources/images/workingicon.png" />
-                  </p:blockUI>
+
                </div>
             </div>
          </div>
@@ -119,9 +99,11 @@
          </p:blockUI>
          <p:confirmDialog global="true">
             <p:commandButton value="Yes" type="button"
-                             styleClass="ui-confirmdialog-yes" icon="fa fa-thumbs-up" />
+                             styleClass="ui-confirmdialog-yes" />
             <p:commandButton value="No" type="button"
-                             styleClass="ui-confirmdialog-no" icon="fa fa-thumbs-down" />
+                             styleClass="ui-confirmdialog-no"
+            style="background-color: red"
+            />
          </p:confirmDialog>
       </h:form>
 


### PR DESCRIPTION
### Description

Styled the Review Cycle UI, including both the table and dialog, for a cleaner and more user-friendly design.

Added a new attribute reviewCycleStatusList to ReviewCycleForm to manage the list of review cycle statuses.

Updated part of the sidebar menu to include/modify Review Cycle related navigation.

### Type of change

- [ ] Others (cosmetics, styling, improvements)

How Has This Been Tested?

- [ ] Unit

- [ ]  Integration


### How can this be Tested?

Navigate to the Review Cycle section via the sidebar.

Verify that the table now appears with the new styling.

Open the Review Cycle dialog and check the updated UI.

Ensure the Status dropdown is populated using reviewCycleStatusList.

Confirm that sidebar navigation to Review Cycle works as expected after menu update.

### Any background context you want to add
These changes are part of improving the usability and visual presentation of the Review Cycle management section, while also preparing for easier status management with the newly introduced reviewCycleStatusList in ReviewCycleForm.