### PR TITLE
Refactor Global weight configuration frontend

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/GlobalWeightForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/GlobalWeightForm.java
@@ -1,16 +1,24 @@
 package org.pahappa.systems.kpiTracker.views.dialogs.systemSetup;
 
+import com.googlecode.genericdao.search.Search;
 import lombok.Getter;
 import lombok.Setter;
 import org.pahappa.systems.kpiTracker.core.services.GlobalWeightService;
+import org.pahappa.systems.kpiTracker.core.services.impl.ReviewCycleService;
 import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
+import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.ReviewCycleStatus;
 import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.utils.GeneralSearchUtils;
 import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.utils.SearchField;
 import org.sers.webutils.server.core.utils.ApplicationContextProvider;
 
 import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
+import java.util.List;
 
 @ManagedBean(name = "globalWeightsForm")
 @Getter
@@ -20,14 +28,18 @@ public class GlobalWeightForm extends DialogForm<GlobalWeight> {
     private static final long serialVersionUID = 1L;
 
     private GlobalWeightService globalWeightService;
+    private List<ReviewCycle> reviewCycleList;
+    private ReviewCycleService reviewCycleService;
 
     public GlobalWeightForm() {
-        super(HyperLinks.GLOBAL_WEIGHT_DIALOG, 800, 700);
+        super(HyperLinks.GLOBAL_WEIGHT_DIALOG, 500, 400);
     }
 
     @PostConstruct
     public void init() {
         globalWeightService = ApplicationContextProvider.getBean(GlobalWeightService.class);
+        reviewCycleService = ApplicationContextProvider.getBean(ReviewCycleService.class);
+        loadReviewCycles();
     }
 
     @Override
@@ -39,7 +51,32 @@ public class GlobalWeightForm extends DialogForm<GlobalWeight> {
     @Override
     public void resetModal() {
         super.resetModal();
+        loadReviewCycles();
         super.model = new GlobalWeight();
+    }
+
+    // In your globalWeightsForm backing bean
+    public void loadReviewCycles() {
+        this.reviewCycleList = reviewCycleService.getAllInstances();
+    }
+
+    public void updateMboWeight() {
+        // A primitive double cannot be null; an empty field defaults to 0.0.
+        double orgFit = model.getOrgFitWeight();
+
+        // Only calculate if the input is within a valid range.
+        if (orgFit >= 0 && orgFit <= 100) {
+            model.setMboWeight(100.0 - orgFit);
+        }
+    }
+
+    public void updateOrgFitWeight() {
+        double mbo = model.getMboWeight();
+
+        // Only calculate if the input is within a valid range.
+        if (mbo >= 0 && mbo <= 100) {
+            model.setOrgFitWeight(100.0 - mbo);
+        }
     }
 
 

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/GlobalWeightView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/GlobalWeightView.java
@@ -68,6 +68,7 @@ public class GlobalWeightView extends PaginatedTableView<GlobalWeight, GlobalWei
     public void deleteClient(GlobalWeight globalWeight) {
         try {
             globalWeightService.deleteInstance(globalWeight);
+            reloadFilterReset();
         } catch (OperationFailedException e) {
             UiUtils.ComposeFailure("Delete Failed", e.getLocalizedMessage());
         }

--- a/frontend/kpi-tracker-web/src/main/java/org/pahappa/systems/client/converters/ReviewCycleConverter.java
+++ b/frontend/kpi-tracker-web/src/main/java/org/pahappa/systems/client/converters/ReviewCycleConverter.java
@@ -1,0 +1,31 @@
+package org.pahappa.systems.client.converters;
+
+import org.pahappa.systems.kpiTracker.core.services.impl.ReviewCycleService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+
+@FacesConverter(value = "reviewCycleConverter")
+public class ReviewCycleConverter implements Converter {
+
+    @Override
+    public Object getAsObject(FacesContext context, UIComponent component, String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return ApplicationContextProvider.getBean(ReviewCycleService.class)
+                .getObjectById(value);
+    }
+
+    @Override
+    public String getAsString(FacesContext context, UIComponent component, Object object) {
+        if (object == null || object instanceof String)
+            return null;
+        return ((ReviewCycle) object).getId();
+    }
+}
+

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeightForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeightForm.xhtml
@@ -4,60 +4,66 @@
                 xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:p="http://primefaces.org/ui"
                 template="/pages/californiatemplate/dialog-template.xhtml">
-    <ui:define name="head">
-        <style type="text/css">
-            .capitalized {
-                text-transform: capitalize;
-            }
-        </style>
-    </ui:define>
+
     <ui:define name="content">
-        <title>Manage Global weight </title>
-        <h:form id="globalWeightDialog" styleClass="card" style="height: 450px;">
-            <div class="p-grid ui-fluid">
+        <h:form id="globalWeightDialog" styleClass="ui-fluid formgrid grid" >
 
-                <!-- Business Goal Weight -->
-                <div class="p-col-12 p-md-3">
-                    <h5>Business goal weight</h5>
-                    <div class="ui-inputgroup">
-                        <p:inputText value="#{globalWeightsForm.model.mboWeight}" required="true"
-                        />
-                    </div>
-                </div>
+            <h3 class="form-title p-mx-4">Manage Global Weight</h3>
+            <p:growl id="growl" showDetail="true" life="4000" />
 
-                <!-- Organizational Fit Weight -->
-                <div class="p-col-12 p-md-3">
-                    <h5>Organizational fit weight</h5>
-                    <div class="ui-inputgroup">
-                        <p:inputText value="#{globalWeightsForm.model.orgFitWeight}" required="true" />
-                    </div>
-                </div>
+            <div class="field col-12 p-m-4">
 
-                <!-- Buttons -->
-                <div class="p-col-12" style="margin-top: 60px;">
-                    <div class="p-grid p-justify-center p-align-center">
-                        <div class="p-col-12 p-md-3">
-                            <p:commandButton value="Cancel"
-                                             validateClient="false"
-                                             process="@this"
-                                             action="#{globalWeightsForm.hide}"
-                                             styleClass="ui-button-outlined ui-button-help"
-                                             style="width: 100%;" />
-                        </div>
-                        <div class="p-col-12 p-md-3">
-                            <p:commandButton value="Save"
-                                             process="@form"
-                                             actionListener="#{globalWeightsForm.persist}"
-                                             update="@form"
-                                             validateClient="true"
-                                             style="width: 100%;" />
-                        </div>
-                    </div>
-                </div>
-
+                <p:selectOneMenu id="reviewCycle" value="#{globalWeightsForm.model.reviewCycle}" converter="reviewCycleConverter" >
+                    <f:selectItem itemLabel="Select Review Cycle" itemValue="#{null}" noSelectionOption="true"/>
+                    <f:selectItems value="#{globalWeightsForm.reviewCycleList}" var="review"  itemLabel="#{review.startDate} #{review.endDate}" itemValue="#{review}"/>
+                </p:selectOneMenu>
             </div>
+
+            <!-- Business Goal Weight -->
+            <div class="field col-12 p-mx-4 p-mb-2">
+                <p:outputLabel for="mboWeightInput" value="Business goal weight" />
+                <p:inputText id="mboWeightInput"
+                             value="#{globalWeightsForm.model.mboWeight}"
+                             required="true">
+                    <p:ajax event="keyup"
+                            listener="#{globalWeightsForm.updateOrgFitWeight}"
+                            process="@this"
+                            update="orgFitWeightInput" />
+                </p:inputText>
+            </div>
+
+            <!-- Organizational Fit Weight -->
+            <div class="field col-12 p-mx-4">
+                <p:outputLabel for="orgFitWeightInput" value="Organizational fit weight" />
+                <p:inputText id="orgFitWeightInput"
+                             value="#{globalWeightsForm.model.orgFitWeight}"
+                             required="true">
+                    <p:ajax event="keyup"
+                            listener="#{globalWeightsForm.updateMboWeight}"
+                            process="@this"
+                            update="mboWeightInput" />
+                </p:inputText>
+            </div>
+
+            <!-- Buttons -->
+            <div class="col-12 p-mx-4" style="margin-top: 2rem; display: flex; justify-content: space-between; gap: 1rem;">
+                <p:commandButton value="Cancel"
+                                 validateClient="false"
+                                 process="@this"
+                                 action="#{globalWeightsForm.hide}"
+                                 styleClass="ui-button-danger p-mx-5"
+                                 style="flex: 1;" />
+
+                <p:commandButton value="Save"
+                                 process="@form"
+                                 actionListener="#{globalWeightsForm.save}"
+                                 update="@form growl"
+                                 validateClient="true"
+                                 style="flex: 1;"
+                                 styleClass="ui-button-primary p-mx-5"
+                />
+            </div>
+
         </h:form>
-
-
     </ui:define>
 </ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeightTable.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/GlobalWeightTable.xhtml
@@ -79,7 +79,8 @@
 
 
                         <p:commandButton icon="fa fa-edit" title="Edit"
-                                         styleClass="ui-button-help" immediate="true"
+                                         styleClass="ui-button-text-icon-primary" immediate="true"
+                                         style="margin-right: 5px"
                                          actionListener="#{globalWeightsForm.show}">
                            <f:setPropertyActionListener value="#{model}"
                                                         target="#{globalWeightsForm.model}" />
@@ -87,8 +88,8 @@
                            <p:ajax event="dialogReturn" update="globalWeightTable" />
                         </p:commandButton>
 
-                        <p:commandButton icon="fa fa-times" title="Delete"
-                                         styleClass="ui-button-help" immediate="true"
+                        <p:commandButton icon="fa fa-trash" title="Delete"
+                                         styleClass="ui-button-danger" immediate="true"
                                          actionListener="#{globalWeightView.deleteClient(model)}" >
                            <p:confirm header="Confirmation"
                                       message="Are you sure you want to delete this record?"


### PR DESCRIPTION
### Description
Added a method for retrieving review cycles that can be attached to a global weight.
 Styled the user interface for the global weight dialog to match the review cycle dialog design.
 Added a ReviewCycleConverter for selecting review cycles in the global weight form.

### Type of change
 New feature (non-breaking change which adds functionality)
Others (styling, improvements)

### How Has This Been Tested?

- [ ] Integration

### How can this be Tested?

Navigate to the Global Weight configuration page.

Open the dialog for adding/editing a global weight.

Verify that the review cycle dropdown is populated with valid cycles.

Select a review cycle and save — ensure it persists without validation errors.

Confirm that the UI styling matches the review cycle dialog style.