### PR TITLE
Fixed bug on review cycle backend

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/ReviewCycle.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/ReviewCycle.java
@@ -70,4 +70,18 @@ public class ReviewCycle extends BaseEntity {
     public void setStatus(ReviewCycleStatus status) {
         this.status = status;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ReviewCycle)) return false;
+        ReviewCycle that = (ReviewCycle) o;
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31;
+    }
+
 }

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ReviewCycleService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ReviewCycleService.java
@@ -4,4 +4,5 @@ import org.pahappa.systems.kpiTracker.core.services.GenericService;
 import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
 
 public interface ReviewCycleService extends GenericService<ReviewCycle> {
+    Object getObjectById(String var1);
 }

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ReviewCycleServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ReviewCycleServiceImpl.java
@@ -22,8 +22,7 @@ public class ReviewCycleServiceImpl extends GenericServiceImpl<ReviewCycle> impl
         return true;
     }
 
-
-
+    @Override
     public Object getObjectById(String id) {
         return super.getInstanceByID(id);
     }


### PR DESCRIPTION
### Description
 Fixed a bug where a review cycle could not be matched during selection in the Global Weight dialog.
 Added equals() and hashCode() methods to the ReviewCycle model to ensure correct matching in JSF components.
 Added a getObjectById method to ReviewCycleService and its implementation to retrieve a review cycle by ID.

Type of change

- [ ]  Bug fix (non-breaking change which fixes an issue)

How Has This Been Tested?

- [ ] Unit

- [ ] Integration

### How can this be Tested?

Navigate to the Global Weight configuration page.

Open the dialog to add or edit a global weight.

Select a review cycle from the dropdown and save.

Reopen the dialog and verify that the selected review cycle is correctly displayed.

Any background context you want to add
Previously, the absence of equals() and hashCode() in ReviewCycle caused JSF validation errors (Value is not valid). Implementing these methods ensures that the dropdown correctly matches existing review cycles. The getObjectById method supports retrieving review cycles directly by ID for converters and other service usages.