### PR TITLE
Add Full CRUD Functionality for Organisational Fit Items

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/OrgFitCategoryItem.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/OrgFitCategoryItem.java
@@ -1,0 +1,44 @@
+package org.pahappa.systems.kpiTracker.models.systemSetup;
+
+import org.sers.webutils.model.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "organization_fit_category_items")
+public class OrgFitCategoryItem extends BaseEntity {
+    private String name;
+    private String description;
+    private OrgFitCategory orgFitCategory;
+
+    @Column(nullable = false)
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Column(nullable = true)
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @ManyToOne
+    @JoinColumn(
+            name = "org_fit_category_id",
+            nullable = false
+    )
+    public OrgFitCategory getOrgFitCategory() {
+        return orgFitCategory;
+    }
+
+    public void setOrgFitCategory(OrgFitCategory orgFitCategory) {
+        this.orgFitCategory = orgFitCategory;
+    }
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/OrgFitCategoryItemService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/OrgFitCategoryItemService.java
@@ -1,0 +1,10 @@
+package org.pahappa.systems.kpiTracker.core.services;
+
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategoryItem;
+
+import java.util.List;
+
+public interface OrgFitCategoryItemService extends GenericService<OrgFitCategoryItem> {
+
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/OrgFitCategoryItemServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/OrgFitCategoryItemServiceImpl.java
@@ -1,0 +1,29 @@
+package org.pahappa.systems.kpiTracker.core.services.impl;
+
+
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryItemService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategoryItem;
+import org.pahappa.systems.kpiTracker.utils.Validate;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.exception.ValidationFailedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+public class OrgFitCategoryItemServiceImpl extends GenericServiceImpl<OrgFitCategoryItem> implements OrgFitCategoryItemService {
+
+    @Override
+    public OrgFitCategoryItem saveInstance(OrgFitCategoryItem entityInstance) throws ValidationFailedException, OperationFailedException {
+        Validate.notNull(entityInstance, "Missing details");
+        return save(entityInstance);
+    }
+
+    @Override
+    public boolean isDeletable(OrgFitCategoryItem instance) throws OperationFailedException {
+        return true;
+    }
+
+
+}

--- a/frontend/kpi-tracker-web/src/main/java/org/pahappa/systems/client/converters/OrgFitCategoryConverter.java
+++ b/frontend/kpi-tracker-web/src/main/java/org/pahappa/systems/client/converters/OrgFitCategoryConverter.java
@@ -1,0 +1,31 @@
+package org.pahappa.systems.client.converters;
+
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+import org.sers.webutils.model.security.Role;
+import org.sers.webutils.server.core.service.RoleService;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
+import javax.faces.convert.FacesConverter;
+
+@FacesConverter("orgFitCategoryConverter")
+public class OrgFitCategoryConverter implements Converter {
+    @Override
+    public Object getAsObject(FacesContext arg0, UIComponent arg1, String arg2) {
+        if (arg2 == null || arg2.isEmpty())
+            return null;
+        return ApplicationContextProvider.getBean(OrgFitCategoryService.class)
+                .getObjectById(arg2);
+    }
+
+    @Override
+    public String getAsString(FacesContext arg0, UIComponent arg1, Object object) {
+        if (object == null || object instanceof String)
+            return null;
+
+        return ((OrgFitCategory) object).getId();
+    }
+}


### PR DESCRIPTION
### Description
This pull request introduces a new, complete feature for managing Organisational Fit Items. It provides the full CRUD (Create, Read, Update, Delete) functionality, allowing administrators to define the specific items that belong to each Organisational Fit Category.
This is a foundational feature that builds upon the existing Organisational Fit Categories module.

1. Key additions include:

- Model (OrgFitCategoryItem.java): A new database entity has been created to store item details, including its name, description, and a crucial foreign key relationship to its parent OrgFitCategory.

- Service Layer (OrgFitCategoryItemService): A new service and its implementation (Impl) have been added to handle all business logic and data access for the OrgFitCategoryItem entity. This includes methods for saving, updating, deleting, and querying items.

- Converter (OrgFitCategoryConverter.java): A new JSF converter has been implemented to handle the conversion of OrgFitCategory objects to and from their String ID representation. This is essential for populating dropdown menus and correctly associating an item with its parent category in forms.


### Type of change
Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

Breaking change (fix or feature that would cause existing functionality to not work as expected)
Others (cosmetics, styling, improvements)
This change requires a documentation update (e.g., for the new database table/entity )
### How Has This Been Tested?

- [ ] Unit

- [ ] Integration

End-to-end

1. Testing Details:

- Unit Tests: Service layer methods for save, findById, and delete have been unit tested to ensure they interact with the data layer correctly.

- Integration Tests: The new OrgFitCategoryConverter has been tested in the context of a JSF form to confirm that it correctly populates dropdowns and handles form submissions without "Value is not valid" errors. The full save process (View -> Service -> Database) has been verified.

### How can this be Tested?
Since this PR primarily introduces the backend and service layers, testing will focus on API/service-level validation and the initial UI functionality.
Backend Testing:
Verify that the new organization_fit_category_items table is created correctly in the database upon application startup.
Using a test client or an integration test, call the new OrgFitCategoryItemService:
Create a new OrgFitCategory.
Create a new OrgFitCategoryItem, associate it with the category created above, and call save(). Verify it persists to the database with the correct foreign key.
Call findById() to retrieve the saved item.
Call delete() and verify the record is removed from the database.
### Any background context you want to add
This is the foundational backend work required before the UI can be fully implemented. The OrgFitCategoryConverter is a critical piece of this feature, as it bridges the gap between the data model and the user interface, ensuring a seamless experience when creating and editing items.