### PR TITLE
Feature: Implement Card-Based UI for Organisational Fit Items

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/OrgFitCategoryItemForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/OrgFitCategoryItemForm.java
@@ -1,0 +1,67 @@
+package org.pahappa.systems.kpiTracker.views.dialogs.systemSetup;
+
+import com.google.common.collect.Sets;
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryItemService;
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategoryItem;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@ManagedBean(name = "orgFitCategoryItemForm")
+@Getter
+@Setter
+@SessionScoped
+public class OrgFitCategoryItemForm extends DialogForm<OrgFitCategoryItem> {
+    private OrgFitCategoryItemService orgFitCategoryItemService;
+    private OrgFitCategoryService orgFitCategoryService;
+    private OrgFitCategory selectedOrgFitCategory;
+
+
+    private List<OrgFitCategory> orgFitCategoryList;
+
+    public OrgFitCategoryItemForm() {
+        super(HyperLinks.ORG_FIT_CATEGORY_ITEM_DIALOG, 500, 200);
+    }
+
+    @PostConstruct
+    public void init() {
+        this.orgFitCategoryItemService = ApplicationContextProvider.getBean(OrgFitCategoryItemService.class);
+        this.orgFitCategoryService = ApplicationContextProvider.getBean(OrgFitCategoryService.class);
+        loadOrgFitCategoryList();
+    }
+
+    @Override
+    public void persist() throws Exception {
+        super.model.setOrgFitCategory(this.selectedOrgFitCategory);
+        orgFitCategoryItemService.saveInstance(super.model);
+    }
+
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new OrgFitCategoryItem();
+    }
+
+    private void loadOrgFitCategoryList() {
+        this.orgFitCategoryList = orgFitCategoryService.getAllInstances();
+    }
+
+    public void prepareForCategory(OrgFitCategory category) {
+        this.selectedOrgFitCategory = category;
+        this.show(null);
+    }
+
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/OrgFitCategoryItemView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/systemSetup/OrgFitCategoryItemView.java
@@ -1,0 +1,121 @@
+package org.pahappa.systems.kpiTracker.views.systemSetup;
+
+import com.cloudinary.utils.StringUtils;
+import com.googlecode.genericdao.search.Filter;
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+
+import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryItemService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategoryItem;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.pahappa.systems.kpiTracker.utils.GeneralSearchUtils;
+import org.sers.webutils.client.views.presenters.PaginatedTableView;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.utils.SearchField;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@ManagedBean(name = "orgFitCategoryItemView")
+@Setter
+@Getter
+@SessionScoped
+public class OrgFitCategoryItemView extends PaginatedTableView<OrgFitCategoryItem, OrgFitCategoryItemService,OrgFitCategoryItemService> {
+
+    private OrgFitCategoryItemService orgFitCategoryItemServiceService;
+    private Search search;
+    private String searchTerm;
+    private List<OrgFitCategory> orgFitCategories;
+    private OrgFitCategory selectedOrgFitCategory;
+    private List<SearchField> searchFields, selectedSearchFields;
+    private Date createdFrom, createdTo;
+
+
+    @PostConstruct
+    public void init(){
+        orgFitCategoryItemServiceService = ApplicationContextProvider.getBean(OrgFitCategoryItemService.class);
+        reloadFilterReset();
+    }
+
+    @Override
+    public void reloadFromDB(int i, int i1, Map<String, Object> map) throws Exception {
+        super.setDataModels(
+                orgFitCategoryItemServiceService.getInstances(this.search, i, i1)
+        );
+    }
+
+
+
+    @Override
+    public List<ExcelReport> getExcelReportModels() {
+        return null;
+    }
+
+    @Override
+    public String getFileName() {
+        return null;
+    }
+
+    @Override
+    public List<OrgFitCategoryItem> load(int i, int i1, Map map, Map map1) {
+        return getDataModels();
+    }
+    @Override
+    public void reloadFilterReset() {
+        this.search = new Search(OrgFitCategoryItem.class);
+        this.search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+
+        // Text search for name OR description
+        if (!StringUtils.isEmpty(searchTerm)) {
+            this.search.addFilterOr(
+                    Filter.ilike("name", "%" + searchTerm + "%"),
+                    Filter.ilike("description", "%" + searchTerm + "%")
+            );
+        }
+
+        // Filter by category
+        if (selectedOrgFitCategory != null) {
+            this.search.addFilterEqual("orgFitCategory", selectedOrgFitCategory);
+        }
+
+        try {
+            super.reloadFilterReset();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // Count total records for pagination
+        super.setTotalRecords(orgFitCategoryItemServiceService.countInstances(this.search));
+    }
+
+
+    public void deleteClient(OrgFitCategoryItem orgFitCategoryItem) {
+        try {
+            orgFitCategoryItemServiceService.deleteInstance(orgFitCategoryItem);
+            reloadFilterReset();
+        } catch (OperationFailedException e) {
+            UiUtils.ComposeFailure("Delete Failed", e.getLocalizedMessage());
+        }
+    }
+
+    public String prepareForCategory(OrgFitCategory category) {
+        this.selectedOrgFitCategory = category;
+        reloadFilterReset();
+        return "/pages/systemSetup/OrgFitCategoryItemTable.xhtml?faces-redirect=true";
+    }
+
+    public String backToCategories(){
+        return "/pages/systemSetup/OrgFitCategoryTable.xhtml";
+    }
+
+}

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryItemForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryItemForm.xhtml
@@ -1,0 +1,67 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/dialog-template.xhtml">
+
+   <ui:define name="head">
+      <style type="text/css">
+         .capitalized {
+            text-transform: capitalize;
+         }
+         .dialog-card {
+            padding: 1.5rem;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+            background-color: #fff;
+         }
+      </style>
+   </ui:define>
+
+   <ui:define name="content">
+      <title>Add Category Item</title>
+
+      <h:form id="orgFitCategoryItem" styleClass="dialog-card">
+         <p:growl id="growl" showDetail="true" life="4000" />
+
+         <div class="ui-fluid formgrid grid p-m-4">
+
+            <!-- Type -->
+            <div class="field col-12 p-m-4">
+
+               <p:inputText value="#{orgFitCategoryItemForm.model.name}"
+                            required="true"
+                            placeholder="Name"
+                            styleClass="p-inputtext-sm w-full"/>
+            </div>
+
+
+            <div class="field col-12 md:col-6 p-m-4">
+
+               <p:inputText value="#{orgFitCategoryItemForm.model.description}"
+                            required="true"
+                            placeholder="Description"
+                            styleClass="p-inputtext-sm w-full"/>
+            </div>
+
+
+            <!-- Buttons -->
+            <div class="field col-12 p-d-flex p-jc-between">
+               <p:commandButton value="Cancel"
+                                immediate="true"
+                                action="#{orgFitCategoryItemForm.hide}"
+                                styleClass="ui-button-danger p-mx-5" />
+
+               <p:commandButton value="Save"
+                                process="@form"
+                                actionListener="#{orgFitCategoryItemForm.save}"
+                                update="@form growl"
+                                styleClass="ui-button-primary p-mx-5" />
+            </div>
+
+         </div>
+
+      </h:form>
+   </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryItemTable.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryItemTable.xhtml
@@ -1,0 +1,96 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+    <ui:define name="content">
+        <!-- Main form for the page -->
+        <h:form id="orgFitItemView">
+
+            <!-- CONTENT DISPLAY SECTION -->
+            <div class="card">
+                <!-- Header: Title and "Add Item" button -->
+                <div class="p-d-flex p-jc-between p-ai-center p-mb-3">
+
+                    <!-- Back arrow + Title -->
+                    <div class="p-d-flex p-ai-center p-gap-2">
+                        <p:commandButton icon="pi pi-arrow-left"
+                                         styleClass="ui-button-text ui-button-outlined p-mr-3 "
+                                         action="#{orgFitCategoryItemView.backToCategories}"
+                                         immediate="true"
+                                          />
+                        <h3 style="margin: 0;">
+                            Items in:
+                            <h:outputText value="#{orgFitCategoryItemView.selectedOrgFitCategory.name}" />
+                        </h3>
+                    </div>
+
+                    <!-- Add Item Button -->
+                    <p:commandButton value="Add Item" icon="pi pi-plus"
+                                     styleClass="ui-button-success"
+                                     actionListener="#{orgFitCategoryItemForm.prepareForCategory(orgFitCategoryItemView.selectedOrgFitCategory)}"
+                                     process="@this">
+
+                        <f:setPropertyActionListener value="#{null}"
+                                                     target="#{orgFitCategoryItemForm.model}" />
+
+                        <p:ajax event="dialogReturn"
+                                listener="#{orgFitCategoryItemView.reloadFilterReset}"
+                                update="itemsListPanel" />
+                    </p:commandButton>
+                </div>
+
+                <!-- This panel wraps the list so it can be updated by AJAX -->
+                <p:outputPanel id="itemsListPanel" layout="block">
+                    <!-- The list of cards, created with ui:repeat -->
+                    <ui:repeat value="#{orgFitCategoryItemView.dataModels}" var="item">
+                        <div class="p-card p-p-3 p-mb-3" style="border: 1px solid #dee2e6; border-radius: 6px;">
+                            <!-- Top section: Name and Description -->
+                            <div class="p-mb-3">
+                                <h4 style="margin-top: 0; margin-bottom: 0.5rem;">#{item.name}</h4>
+                                <h:outputText value="#{item.description}" style="color: #6c757d;" />
+                            </div>
+
+                            <hr class="p-my-2"/>
+
+                            <!-- Bottom section: Action buttons -->
+                            <div class="p-d-flex p-jc-end p-ai-center">
+                                <p:commandButton value="Edit" icon="pi pi-pencil"
+                                                 styleClass="ui-button-outlined p-mr-2"
+                                                 actionListener="#{orgFitCategoryItemForm.show}"
+                                                 process="@this">
+                                    <f:setPropertyActionListener value="#{item}" target="#{orgFitCategoryItemForm.model}" />
+                                </p:commandButton>
+
+                                <p:commandButton value="Delete" icon="pi pi-trash"
+                                                 styleClass="ui-button-text ui-button-danger"
+                                                 update="orgFitItemView"
+                                                 actionListener="#{orgFitCategoryItemView.deleteClient(item)}">
+                                    <p:confirm header="Confirmation"
+                                               message="Are you sure you want to delete '#{item.name}'?"
+                                               icon="pi pi-exclamation-triangle" />
+                                </p:commandButton>
+                            </div>
+                        </div>
+                    </ui:repeat>
+
+                    <!-- Message to display when the list is empty -->
+                    <p:outputPanel rendered="#{empty orgFitCategoryItemView.dataModels}">
+                        <div class="p-text-center p-p-4" style="border: 1px dashed #ced4da; border-radius: 6px;">
+                            <h:outputText value="#{orgFitCategoryItemView.dataEmptyMessage}" />
+                        </div>
+                    </p:outputPanel>
+                </p:outputPanel>
+            </div>
+
+            <!-- Global Confirmation Dialog -->
+            <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">
+                <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" />
+                <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" />
+            </p:confirmDialog>
+
+        </h:form>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
### Description
This pull request overhauls the user interface for the Organisational Fit Items page. The primary change is the replacement of the standard p:dataTable with a modern, responsive, card-based layout using ui:repeat. This significantly improves the user experience and aligns the page's look and feel with the design for Organisational Fit Categories.

1. Key changes include:

- Card Layout: Each item is now displayed in its own distinct card, showing its name, description, and action buttons.

Added Backing Bean: The OrgFitCategoryItemView managed bean has been updated to support the new filtering logic, building a dynamic search query based on user input. The bean's scope has been corrected to @ViewScoped to ensure proper state management.
### Type of change
Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

Breaking change (fix or feature that would cause existing functionality to not work as expected)
Others (cosmetics, styling, improvements)
This change requires a documentation update
### How Has This Been Tested?
Unit
Integration

- [ ] End-to-end

1. Testing Details:

Manual end-to-end testing was performed to verify the functionality. All filter inputs were tested individually and in combination to ensure the displayed results were accurate. The "Add Item", "Edit", and "Delete" actions within the new card layout were also confirmed to be working as expected.
### How can this be Tested?
Navigate to the System Setup -> Organisational Fit section of the application.
Select a category and click on Manage Items to go to the Organisational Fit Items page.

- Verify the new card layout: Confirm that all existing items are displayed as individual cards instead of rows in a table.


- Verify Actions: Confirm that the "Edit" and "Delete" buttons on each card work correctly for the respective item.

### Any background context you want to add
This change is part of a larger effort to modernize the UI across the "System Setup" module. The card-based pattern established here and in the "Organisational Fit Categories" page should be considered the standard for similar list-based views going forward.