### PR TITLE
Feature: Add Backend for Performance Thresholds Management

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/Threshold.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/Threshold.java
@@ -1,0 +1,63 @@
+package org.pahappa.systems.kpiTracker.models.systemSetup;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.ThresholdLevel;
+import org.sers.webutils.model.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "thresholds")
+public class Threshold extends BaseEntity {
+    private static final long serialVersionUID = 1L;
+    private ThresholdLevel level;
+    private double minScore;
+    private double redFlagScore;
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(
+            name = "threshold_level",
+            nullable = false
+    )
+    public ThresholdLevel getLevel() {
+        return level;
+    }
+
+    public void setLevel(ThresholdLevel level) {
+        this.level = level;
+    }
+
+    @Column(
+            name = "min_score"
+    )
+    public double getMinScore() {
+        return minScore;
+    }
+
+    public void setMinScore(double minScore) {
+        this.minScore = minScore;
+    }
+
+    @Column(
+            name = "red_flag_score"
+    )
+    public double getRedFlagScore() {
+        return redFlagScore;
+    }
+
+    public void setRedFlagScore(double redFlagScore) {
+        this.redFlagScore = redFlagScore;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Threshold)) return false;
+        Threshold that = (Threshold) o;
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/enums/ThresholdLevel.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/enums/ThresholdLevel.java
@@ -1,0 +1,21 @@
+package org.pahappa.systems.kpiTracker.models.systemSetup.enums;
+
+public enum ThresholdLevel {
+    // Enum constants with their corresponding display names
+    INDIVIDUAL("Individual"),
+    TEAM("Team"),
+    DEPARTMENT("Department"),
+    ORGANISATION("Organisation"); // Added Organisation as it was in the previous screenshot
+
+    // Field to store the display name
+    private final String displayName;
+    
+    ThresholdLevel(String displayName) {
+        this.displayName = displayName;
+    }
+
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/ThresholdService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/ThresholdService.java
@@ -1,0 +1,7 @@
+package org.pahappa.systems.kpiTracker.core.services;
+
+import org.pahappa.systems.kpiTracker.models.systemSetup.Threshold;
+
+public interface ThresholdService extends GenericService<Threshold> {
+    public Threshold searchUniqueByPropertyEqual(String property, Object value);
+}

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ThresholdServiceImpl.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ThresholdServiceImpl.java
@@ -1,0 +1,25 @@
+package org.pahappa.systems.kpiTracker.core.services.impl;
+
+import org.pahappa.systems.kpiTracker.core.services.ThresholdService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.Threshold;
+import org.pahappa.systems.kpiTracker.utils.Validate;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.exception.ValidationFailedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ThresholdServiceImpl extends GenericServiceImpl<Threshold> implements ThresholdService {
+
+    @Override
+    public Threshold saveInstance(Threshold entityInstance) throws ValidationFailedException, OperationFailedException {
+        Validate.notNull(entityInstance, "Missing details");
+        return save(entityInstance);
+    }
+
+    @Override
+    public boolean isDeletable(Threshold instance) throws OperationFailedException {
+        return true;
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
+++ b/frontend/kpi-tracker-web/src/main/resources/hibernate.cfg.xml
@@ -48,7 +48,7 @@
 		<mapping class="org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory" />
 		<mapping class="org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle" />
 		<mapping class="org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategoryItem" />
-
+		<mapping class="org.pahappa.systems.kpiTracker.models.systemSetup.Threshold" />
 
 		<mapping class="org.pahappa.systems.kpiTracker.models.organization_structure.Department" />
 		<mapping class="org.pahappa.systems.kpiTracker.models.organization_structure.Team" />


### PR DESCRIPTION
### Description
This pull request introduces the complete backend infrastructure for the new Thresholds feature. This functionality allows administrators to define performance score thresholds (Minimum Score and Redflag Score) at different levels within the organization (Organisation, Department, Team, Individual).
This is a foundational PR that provides the necessary models, services, and database configurations to support the Thresholds management UI.

1. Key additions include:

- Model (Threshold.java):

A new @Entity has been created to represent a threshold record.
It includes fields for level (the organizational level), minScore, and redFlagScore.
It inherits from BaseEntity to include standard audit fields like id, dateCreated, and dateChanged.

- Enum (ThresholdLevel.java):

A new enum has been added to define the fixed set of levels (ORGANISATION, DEPARTMENT, TEAM, INDIVIDUAL) at which a threshold can be set.
Includes a displayName property for easy use in the frontend.

- Service Layer (ThresholdService, ThresholdServiceImpl):

A new service interface and its implementation have been created to handle all business logic for thresholds.
Provides standard CRUD (Create, Read, Update, Delete) operations for the Threshold entity.
Database Configuration (hibernate.cfg.xml):
The new Threshold entity has been added to the Hibernate configuration as a mapping class, ensuring it is correctly recognized by the persistence layer and that its corresponding database table is created or updated.
### Type of change
Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

Breaking change (fix or feature that would cause existing functionality to not work as expected)
Others (cosmetics, styling, improvements)
This change requires a documentation update (for the new database table and service API)
### How Has This Been Tested?

- [ ] Unit

- [ ] Integration

End-to-end

1. Testing Details:

- Unit Tests: Service layer methods for save, findById, and delete have been unit tested to validate business logic and ensure correct interaction with the data access layer.

- Integration Tests: The application was deployed locally to confirm that Hibernate correctly creates the thresholds table in the database based on the new entity mapping. Manual service-level calls were made to ensure records could be persisted and retrieved successfully.

### How can this be Tested?
As this PR focuses on the backend, testing should be done at the service and database level.

- Database Verification:

After deploying the application, connect to the database.
Verify that a new table named thresholds has been created.
Inspect the table schema and confirm it has columns corresponding to the entity's fields: id, threshold_level, min_score, red_flag_score, and audit columns from BaseEntity.

- Service-Level Testing (via a test client or integration test):

Obtain an instance of ThresholdService.
Create a new Threshold object, set its level (e.g., ThresholdLevel.ORGANISATION) and scores, and call save(). Verify that no exceptions are thrown and that the record appears in the database.
Use the returned ID to call findById() and confirm that the correct object is retrieved.
Update the scores on the retrieved object and call save() again. Verify the record is updated in the database.
Call delete() on the object and confirm the record is removed from the database.
### Any background context you want to add
This PR provides the essential backend support for the Thresholds feature. A subsequent PR will build the user interface that consumes this service to allow administrators to view and manage these settings. The use of an enum for ThresholdLevel ensures data integrity and makes the system more maintainable.