### PR TITLE
Refactor: Enhance Org Fit Category with Weight Validation and UI Improvements

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/OrgFitCategory.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/systemSetup/OrgFitCategory.java
@@ -11,7 +11,6 @@ public class OrgFitCategory extends BaseEntity {
     private String name;
     private String description;
     private double weight;
-    private OrgFitCategoryType type;
 
     @Column(nullable = false)
     public String getName() {
@@ -40,15 +39,4 @@ public class OrgFitCategory extends BaseEntity {
         this.weight = weight;
     }
 
-    @Column(
-            name = "org_fit_category_type",
-            updatable = false)
-    @Enumerated(EnumType.STRING)
-    public OrgFitCategoryType getType() {
-        return type;
-    }
-
-    public void setType(OrgFitCategoryType type) {
-        this.type = type;
-    }
 }

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/OrgFitCategoryMigration.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/OrgFitCategoryMigration.java
@@ -21,16 +21,15 @@ public class OrgFitCategoryMigration {
     private OrgFitCategoryService orgFitCategory;
 
     @Migration(orderNumber = 2)
-    public void initializeDefaultOrgFitCategories() {
-        createIfNotExists(OrgFitCategoryType.TEAM_RATING, "Team Rating", "Collaboration, Communication, etc.", 5.0);
-        createIfNotExists(OrgFitCategoryType.COMPANY_VALUES, "Company Values", "Self-management, Resource management, etc.", 20.0);
-        createIfNotExists(OrgFitCategoryType.KEEPER_TEST, "Keeper Test", "Competence, Growth, Innovation", 15.0);
+    public void initializeDefaultOrgFitCategories1() {
+        createIfNotExists("Team Rating", "Collaboration, Communication, etc.", 5.0);
+        createIfNotExists("Company Values", "Self-management, Resource management, etc.", 20.0);
+        createIfNotExists( "Keeper Test", "Competence, Growth, Innovation", 15.0);
     }
 
-    private void createIfNotExists(OrgFitCategoryType type, String name, String description, double weight) {
+    private void createIfNotExists(String name, String description, double weight) {
         if (orgFitCategory.getAllInstances().isEmpty()) {
             OrgFitCategory category = new OrgFitCategory();
-            category.setType(type);
             category.setName(name);
             category.setDescription(description);
             category.setWeight(weight);

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/OrgFitCategoryForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/dialogs/systemSetup/OrgFitCategoryForm.java
@@ -1,20 +1,31 @@
 package org.pahappa.systems.kpiTracker.views.dialogs.systemSetup;
 
 
+import org.pahappa.systems.kpiTracker.core.services.GlobalWeightService;
 import org.pahappa.systems.kpiTracker.core.services.OrgFitCategoryService;
+import org.pahappa.systems.kpiTracker.core.services.impl.ReviewCycleService;
+import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
 import org.pahappa.systems.kpiTracker.models.systemSetup.OrgFitCategory;
+import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.ReviewCycleStatus;
 import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
 import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
 import org.sers.webutils.server.core.utils.ApplicationContextProvider;
 
 import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.SessionScoped;
+import java.util.List;
 
 @ManagedBean(name = "orgFitCategoryForm")
 @SessionScoped
 public class OrgFitCategoryForm extends DialogForm<OrgFitCategory> {
     private OrgFitCategoryService orgFitCategoryService;
+    private GlobalWeightService globalWeightService;
+    private ReviewCycleService reviewCycleService;
+    private double globalWeight;
+
 
     public OrgFitCategoryForm() {
         super(HyperLinks.ORG_FIT_CATEGORY_DIALOG, 500, 300);
@@ -23,13 +34,29 @@ public class OrgFitCategoryForm extends DialogForm<OrgFitCategory> {
     @PostConstruct
     public void init() {
         this.orgFitCategoryService = ApplicationContextProvider.getBean(OrgFitCategoryService.class);
-
+        this.globalWeightService = ApplicationContextProvider.getBean(GlobalWeightService.class);
+        this.reviewCycleService = ApplicationContextProvider.getBean(ReviewCycleService.class);
+        this.globalWeight = getGlobalWeightForActiveCycle().getOrgFitWeight();
     }
 
     @Override
     public void persist() throws Exception {
 
-        orgFitCategoryService.saveInstance(super.model);
+        double totalWeight = orgFitCategoryService.getAllInstances().stream()
+                .mapToDouble(OrgFitCategory::getWeight)
+                .sum();
+
+        if (totalWeight + super.model.getWeight() <= globalWeight) {
+            orgFitCategoryService.saveInstance(super.model);
+        }else {
+            UiUtils.showMessageBox("Weight limit reached","The weight don't match config");
+        }
+
+    }
+
+    public GlobalWeight getGlobalWeightForActiveCycle() {
+        ReviewCycle activeReviewCycle = this.reviewCycleService.searchUniqueByPropertyEqual("status", ReviewCycleStatus.ACTIVE);
+        return this.globalWeightService.searchUniqueByPropertyEqual("reviewCycle", activeReviewCycle);
     }
 
 

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryTable.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/systemSetup/OrgFitCategoryTable.xhtml
@@ -4,6 +4,20 @@
                 xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:p="http://primefaces.org/ui"
                 template="/pages/californiatemplate/template.xhtml">
+    <h:outputStylesheet>
+        <style>
+            .progress-red .ui-progressbar-value {
+                background-color: #dc3545 !important; /* red */
+            }
+            .progress-yellow .ui-progressbar-value {
+                background-color: #ffc107 !important; /* yellow */
+            }
+            .progress-green .ui-progressbar-value {
+                background-color: #28a745 !important; /* green */
+            }
+        </style>
+
+    </h:outputStylesheet>
 
     <ui:define name="content">
         <div class="card">
@@ -29,6 +43,7 @@
                 </div>
 
                 <!-- 2. CONTENT LIST: Using ui:repeat to create custom cards -->
+                <p:outputPanel id="categoryListPanel">
                 <ui:repeat value="#{orgFitCategoryView.dataModels}" var="category">
                     <div class="p-card p-p-3 p-mb-3" style="border: 1px solid #dee2e6; border-radius: 6px;">
 
@@ -60,6 +75,7 @@
 
                                 <p:commandButton value="Delete" icon="pi pi-trash"
                                                  styleClass="p-button-text ui-button-danger"
+                                                 update=":orgFitForm:categoryListPanel :orgFitForm:weightPanel"
                                                  actionListener="#{orgFitCategoryView.deleteClient(category)}">
                                     <p:confirm header="Confirmation"
                                                message="Are you sure you want to delete '#{category.name}'?"
@@ -69,7 +85,7 @@
                         </div>
                     </div>
                 </ui:repeat>
-
+                </p:outputPanel>
                 <!-- Check if the list is empty -->
                 <p:outputPanel rendered="#{empty orgFitCategoryView.dataModels}">
                     <div class="p-text-center p-p-4" style="border: 1px dashed #ced4da; border-radius: 6px;">
@@ -77,13 +93,19 @@
                     </div>
                 </p:outputPanel>
 
-                <!-- 3. FOOTER: Total Weight Progress Bar -->
-                <div class="p-d-flex p-jc-end p-ai-center p-mt-4">
-                    <h:outputText value="Total weight" style="font-weight: bold; margin-right: 1rem;" />
-                    <!-- You will need a 'totalWeight' property in your backing bean -->
-                    <p:progressBar value="#{orgFitCategoryView.totalWeight}" style="width: 300px; height: 12px; margin-right: 1rem;" />
-                    <h:outputText value="#{orgFitCategoryView.totalWeight}%" style="font-weight: bold;" />
-                </div>
+                <p:outputPanel id="weightPanel">
+                    <div class="p-d-flex p-jc-end p-ai-center p-mt-4">
+                        <h:outputText value="Total weight" style="font-weight: bold; margin-right: 1rem;" />
+
+                        <p:progressBar value="#{orgFitCategoryView.totalWeight}"
+                                       style="width: 300px; height: 14px; margin-right: 1rem;"
+                                       styleClass="#{orgFitCategoryView.totalWeight lt 50 ? 'progress-red' :
+                             (orgFitCategoryView.totalWeight lt 100 ? 'progress-yellow' : 'progress-green')}" />
+
+
+                        <h:outputText value="#{orgFitCategoryView.totalWeight}%" style="font-weight: bold;" />
+                    </div>
+                </p:outputPanel>
 
                 <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">
                     <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes" />


### PR DESCRIPTION
### Description
This pull request introduces a significant refactor and enhancement of the Organisational Fit Categories feature. The primary goals of this update are to simplify the data model, introduce critical business logic for weight management, and improve the overall user experience.
Key changes include:

1. Strict Weight Validation:

A new validation rule has been implemented in the OrgFitCategoryForm bean.
Before saving a new or edited category, the system now calculates the sum of all existing category weights and adds the weight of the new/edited category.
This total is validated against the Organisational Fit Weight value set in the Global Weights configuration.
The save operation will fail and display an error message if the new total exceeds the globally configured limit, ensuring data integrity.

2. Removal of type Attribute:

The type attribute has been removed from the OrgFitCategory model as it was determined to be redundant.
All associated backend code (services, beans) and frontend UI components have been updated to remove any dependency on this attribute. This simplifies the data model and the associated logic.

3. Database Migration and Default Data:

A new database migration script has been added. This script handles the removal of the type column from the organization_fit_category table.
The migration also populates the table with a set of default categories on a fresh setup, ensuring the feature is immediately usable after deployment.

4. UI/UX Enhancements:

Accurate Progress Bar: The "Total weight" progress bar on the Organisational Fit page now correctly recalculates its value after any add, edit, or delete operation, providing immediate and accurate visual feedback.

Auto-refresh on Delete: When a category is deleted, the page now automatically refreshes the list (reloadFilterReset), so the user doesn't have to manually reload the page to see the change.

The user interface (orgFitCategoryTable.xhtml and related components) has been cleaned up to reflect the removal of the type attribute.
### Type of change
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Breaking change (fix or feature that would cause existing functionality to not work as expected)

- [ ] Others (cosmetics, styling, improvements)

This change requires a documentation update
(Note: The removal of a model attribute and a database column constitutes a breaking change.)
### How Has This Been Tested?

- [ ] Unit

Integration

- [ ] End-to-end

1. Testing Details:

- Unit tests were added for the new weight validation logic within the service/form layer.

Integration testing was performed to ensure the save operation correctly interacts with both the OrgFitCategory and GlobalWeight services to enforce the new rule.

- End-to-end manual testing was conducted to verify the complete user flow, from setting the global weight to creating/editing/deleting categories and observing the UI feedback.

### How can this be Tested?

- Scenario 1: Test Weight Validation

Navigate to System Setup -> Global weights. Set the "Organizational fit weight" to 100. Save.
Navigate to System Setup -> Organisational Fit.
Add a new category with a weight of 70. It should save successfully. The progress bar should show 70%.
Add another new category with a weight of 30. It should save successfully. The progress bar should show 100%.
Attempt to add a third category with any weight (e.g., 10). The save operation must fail, and an error message should be displayed indicating that the total weight exceeds the global limit.
Edit the category with weight 70 and try to change it to 80. This should also fail because 80 + 30 > 100.

- Scenario 2: Test UI Refresh and Progress Bar

Using the state from the previous test (total weight at 100%), delete the category with weight 30.
Verify that the category card is immediately removed from the view without a manual page refresh.
Verify that the progress bar automatically updates to show 70%.

- Scenario 3: Test Database Migration

Deploy this branch on a fresh, empty database.
After the application starts, inspect the organization_fit_category table.
Verify that the type column does not exist.
Verify that the table contains the default categories created by the new migration script.
### Any background context you want to add
This refactor is a critical step towards making the Organisational Fit feature more robust and user-friendly. The introduction of weight validation prevents misconfiguration and ensures the integrity of the performance evaluation system. The simplification of the data model will make future development on this feature easier.