### PR TITLE
Feature: Search unique entity by a property 

### DIFF
--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/GlobalWeightService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/GlobalWeightService.java
@@ -4,4 +4,5 @@ import org.pahappa.systems.kpiTracker.models.systemSetup.GlobalWeight;
 
 public interface GlobalWeightService extends GenericService<GlobalWeight> {
     GlobalWeight mergeBG(GlobalWeight entity);
+    GlobalWeight searchUniqueByPropertyEqual(String property, Object value);
 }

--- a/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ReviewCycleService.java
+++ b/backend/kpi-tracker-services/src/main/java/org/pahappa/systems/kpiTracker/core/services/impl/ReviewCycleService.java
@@ -4,5 +4,6 @@ import org.pahappa.systems.kpiTracker.core.services.GenericService;
 import org.pahappa.systems.kpiTracker.models.systemSetup.ReviewCycle;
 
 public interface ReviewCycleService extends GenericService<ReviewCycle> {
+    ReviewCycle searchUniqueByPropertyEqual(String property, Object value);
     Object getObjectById(String var1);
 }


### PR DESCRIPTION


#### Description
Added the search unique by property method to GlobalWeightService andReviewCycleService to allow retrieve only Global weight for only active review cycle
#### Type of change
=> Please select the relevant option
 Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 Others (cosmetics, styling, improvements)
 This change requires a documentation update
#### How Has This Been Tested?
=> Please select the relevant option
 Unit
 Integration
- [ ] End-to-end
#### How can this be Tested?
Pull the repositoty, go to project structure, services, systemSetup and open the GlobalWeightService and ReviewCycleService files and should see the method added. Then go to any other class and should be able to use that method using an object  of these service classes
#### Any background context you want to add
