### PR TITLE
Feat: Implement UI for Team Goals Management

### DIFF
--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
@@ -24,5 +24,8 @@ public class HyperLinks {
     public static final String ORG_FIT_CATEGORY_ITEM_DIALOG = "/pages/systemSetup/OrgFitCategoryItemForm.xhtml";
     public static final String ORG_FIT_CATEGORY_ITEM_TABLE = "/pages/systemSetup/OrgFitCategoryItemTable.xhtml?faces-redirect=true";
     public static final String THRESHOLD_DIALOG = "/pages/systemSetup/ThresholdForm.xhtml";
+    public static final String ORGANIZATION_GOAL_DIALOG = "/pages/goals/OrganizationGoalForm.xhtml";
+    public static final String DEPARTMENT_GOAL_DIALOG = "/pages/goals/DepartmentGoalForm.xhtml";
+    public static final String TEAM_GOAL_DIALOG = "/pages/goals/TeamGoalForm.xhtml";
 
 }

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goals/TeamGoalForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goals/TeamGoalForm.java
@@ -1,0 +1,78 @@
+package org.pahappa.systems.kpiTracker.views.goals;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.goals.TeamGoalService;
+import org.pahappa.systems.kpiTracker.core.services.goals.DepartmentGoalService;
+import org.pahappa.systems.kpiTracker.core.services.organization_structure_services.TeamService;
+import org.pahappa.systems.kpiTracker.models.goals.DepartmentGoal;
+import org.pahappa.systems.kpiTracker.models.goals.OrganizationGoal;
+import org.pahappa.systems.kpiTracker.models.goals.TeamGoal;
+import org.pahappa.systems.kpiTracker.models.organization_structure.Department;
+import org.pahappa.systems.kpiTracker.models.organization_structure.Team;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.model.security.User;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+import org.sers.webutils.server.shared.SharedAppData;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import java.util.List;
+
+@ManagedBean(name = "teamGoalForm")
+@Getter
+@Setter
+@ViewScoped
+public class TeamGoalForm extends DialogForm<TeamGoal> {
+    private static final long serialVersionUID = 1L;
+    private TeamGoalService teamGoalService;
+    private DepartmentGoalService departmentGoalService;
+    private List<DepartmentGoal> departmentGoals;
+    private TeamService teamService;
+    private Team team;
+    private User loggedinUser;
+
+    public TeamGoalForm() {
+        super(HyperLinks.TEAM_GOAL_DIALOG, 500, 400);
+    }
+
+    @PostConstruct
+    public void init() {
+        this.teamGoalService = ApplicationContextProvider.getBean(TeamGoalService.class);
+        this.departmentGoalService = ApplicationContextProvider.getBean(DepartmentGoalService.class);
+        this.departmentGoals = this.departmentGoalService.getAllInstances();
+        this.teamService = ApplicationContextProvider.getBean(TeamService.class);
+        loggedinUser = SharedAppData.getLoggedInUser();
+        loadDepartment();
+    }
+
+    @Override
+    public void persist() throws Exception {
+        if (model.getName() == null) {
+            UiUtils.showMessageBox("Missing goal name","Goal must have a type.");
+            return;
+        }
+        model.setTeam(team);
+        teamGoalService.saveInstance(super.model);
+    }
+
+    public void loadDepartment() {
+        if (loggedinUser.hasRole("TEAM_LEAD")) {
+            this.team = teamService.getAllInstances()
+                    .stream()
+                    .filter(d -> d.getTeamHead() != null
+                            && d.getTeamHead().equals(loggedinUser))
+                    .findFirst()
+                    .orElse(null);
+        }
+    }
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new TeamGoal();
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goals/TeamGoalView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/goals/TeamGoalView.java
@@ -1,0 +1,74 @@
+package org.pahappa.systems.kpiTracker.views.goals;
+
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.goals.TeamGoalService;
+import org.pahappa.systems.kpiTracker.models.goals.TeamGoal;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.sers.webutils.client.views.presenters.PaginatedTableView;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ViewScoped;
+import java.util.List;
+import java.util.Map;
+
+@ManagedBean(name = "teamGoalView")
+@Getter
+@Setter
+@ViewScoped
+public class TeamGoalView extends PaginatedTableView<TeamGoal,TeamGoalView,TeamGoalView> {
+    private TeamGoalService teamGoalService;
+    private Search search;
+
+
+    @PostConstruct
+    public void init(){
+        this.teamGoalService = ApplicationContextProvider.getBean(TeamGoalService.class);
+        reloadFilterReset();
+    }
+    @Override
+    public void reloadFromDB(int i, int i1, Map<String, Object> map) throws Exception {
+        super.setDataModels(teamGoalService.getInstances(new Search().addFilterEqual("recordStatus", RecordStatus.ACTIVE),i,i1));
+    }
+
+    @Override
+    public List<ExcelReport> getExcelReportModels() {
+        return null;
+    }
+
+    @Override
+    public String getFileName() {
+        return null;
+    }
+
+    @Override
+    public List load(int i, int i1, Map map, Map map1) {
+        return null;
+    }
+
+    @Override
+    public void reloadFilterReset(){
+        super.setTotalRecords(teamGoalService.countInstances(new Search()));
+        try{
+            super.reloadFilterReset();
+        }catch(Exception e){
+            UiUtils.ComposeFailure("Error",e.getLocalizedMessage());
+        }
+
+    }
+
+    public void deleteClient(TeamGoal teamGoal) {
+        try {
+            teamGoalService.deleteInstance(teamGoal);
+            reloadFilterReset();
+        } catch (OperationFailedException e) {
+            UiUtils.ComposeFailure("Delete Failed", e.getLocalizedMessage());
+        }
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
@@ -15,6 +15,34 @@
                                 icon="pi pi-th-large"
                                 styleClass="p-my-3"
                                 outcome="/pages/dashboard/Dashboard" />
+                    <p:submenu id="goals" label="Manage Goals"
+                               styleClass="p-my-3"
+                               style="color:#0d6efd"
+                               icon="pi pi-fw pi-user">
+                        <p:menuitem id="orgGoals" value="Organization Goals"
+                                    rendered="#{dashboard.loggedinUser.hasRole('ROLE_ADMINISTRATOR')}"
+                                    outcome="/pages/goals/OrganizationGoalsView" />
+
+                    </p:submenu>
+
+                    <p:submenu id="department" label="Manage Department"
+                               rendered="#{dashboard.loggedinUser.hasRole('DEPT_LEAD')}"
+                               styleClass="p-my-3"
+                               style="color:#0d6efd"
+                               icon="pi pi-fw pi-user">
+                        <p:menuitem id="departmentGoals" value="Goals"
+                                    outcome="/pages/goals/DepartmentGoalView" />
+                    </p:submenu>
+                    <p:submenu id="team" label="Manage Team"
+                               rendered="#{dashboard.loggedinUser.hasRole('TEAM_LEAD')}"
+                               styleClass="p-my-3"
+                               style="color:#0d6efd"
+                               icon="pi pi-fw pi-user">
+                        <p:menuitem id="teamGoals" value="Team Goals"
+                                    rendered="#{dashboard.loggedinUser.hasRole('TEAM_LEAD')}"
+                                    outcome="/pages/goals/TeamGoalView" />
+                    </p:submenu>
+
 
                     <p:menuitem id="organizationStructure" value="Organization Structure"
                                 icon="pi pi-sitemap"
@@ -22,6 +50,7 @@
                                 outcome="/pages/organizationstructure/OrganizationStructure" />
 
                     <p:submenu id="settings" label="Manage Users"
+                               rendered="#{dashboard.loggedinUser.hasRole('ROLE_ADMINISTRATOR')}"
                                styleClass="p-my-3"
                                style="color:#0d6efd"
                                icon="pi pi-fw pi-user">

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/goals/TeamGoalForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/goals/TeamGoalForm.xhtml
@@ -1,0 +1,71 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/dialog-template.xhtml">
+    <ui:define name="head">
+        <style type="text/css">
+            .capitalized {
+                text-transform: capitalize;
+            }
+        </style>
+    </ui:define>
+    <ui:define name="content">
+        <title>Add Team Goals</title>
+
+        <h:form id="orgGoalForm" styleClass="dialog-card">
+            <p:growl id="growl" showDetail="true" life="4000" />
+
+            <div class="ui-fluid formgrid grid p-m-4">
+
+                <!-- Type -->
+                <div class="field col-12 p-m-4">
+
+                    <p:inputText value="#{teamGoalForm.model.name}"
+                                 required="true"
+                                 placeholder="Name"
+                                 styleClass="p-inputtext-sm w-full"/>
+                </div>
+
+
+                <div class="field col-12 md:col-6 p-m-4">
+
+                    <p:inputText value="#{teamGoalForm.model.description}"
+                                 required="true"
+                                 placeholder="Description"
+                                 styleClass="p-inputtext-sm w-full"/>
+                </div>
+                <div class="field col-12 p-m-4">
+
+                    <p:selectOneMenu id="teamGoal" value="#{teamGoalForm.model.parent}" converter="departmentGoalConverter" >
+                        <f:selectItem itemLabel="Select department parent goal" itemValue="#{null}" noSelectionOption="true"/>
+                        <f:selectItems value="#{teamGoalForm.departmentGoals}" var="parentGoal"  itemLabel="#{parentGoal.name} " itemValue="#{parentGoal}"/>
+                    </p:selectOneMenu>
+                </div>
+                <div class="field col-12 md:col-6 p-m-4">
+                    <p:inputText value="#{teamGoalForm.model.contributionWeight}" required="true"
+                                 placeholder="Weight"
+                                 styleClass="p-inputtext-sm w-full"
+                    />
+                </div>
+
+                <!-- Buttons -->
+                <div class="field col-12 p-d-flex p-jc-between">
+                    <p:commandButton value="Cancel"
+                                     immediate="true"
+                                     action="#{teamGoalForm.hide}"
+                                     styleClass="ui-button-danger p-mx-5" />
+
+                    <p:commandButton value="Save"
+                                     process="@form"
+                                     actionListener="#{teamGoalForm.save}"
+                                     update="@form growl"
+                                     styleClass="ui-button-primary p-mx-5" />
+                </div>
+
+            </div>
+
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/goals/TeamGoalView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/goals/TeamGoalView.xhtml
@@ -1,0 +1,94 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+    <ui:define name="content">
+        <h:form id="goalForm">
+
+            <p:growl id="growl" showDetail="true" life="4000" />
+
+            <!-- Page Title -->
+            <div class="p-d-flex p-jc-between p-ai-center p-mb-3">
+                <h2>Team Goals</h2>
+                <p:commandButton value="Set Goal" icon="pi pi-plus"
+                                 styleClass="ui-button-success"
+                                 actionListener="#{teamGoalForm.show}">
+                    <f:setPropertyActionListener value="#{null}" target="#{teamGoalForm.model}"/>
+                    <p:ajax event="dialogReturn" listener="#{teamGoalView.reloadFilterReset}" update="goalForm"/>
+                </p:commandButton>
+            </div>
+
+            <!-- Filters -->
+            <div class="p-d-flex p-ai-center p-mb-4">
+                <p:commandButton value="All" styleClass="ui-button-primary p-mr-2" />
+                <p:selectOneMenu value="..." style="margin-right:1rem;">
+                    <f:selectItem itemLabel="Level" itemValue=""/>
+                    <f:selectItems value="..."/>
+                </p:selectOneMenu>
+                <p:selectOneMenu value="..." style="margin-right:1rem;">
+                    <f:selectItem itemLabel="Status" itemValue=""/>
+                    <f:selectItems value="..."/>
+                </p:selectOneMenu>
+                <p:inputText placeholder="Search Goal" value="..." style="flex:1"/>
+            </div>
+
+            <!-- Goal Cards -->
+            <ui:repeat value="#{teamGoalView.dataModels}" var="goal">
+                <div class="p-card p-p-3 p-mb-3"
+                     style="border: 1px solid #dee2e6; border-radius: 10px; box-shadow: 0 2px 4px rgba(0,0,0,0.05);">
+
+                    <!-- Goal Title -->
+                    <h3 style="margin: 0; margin-bottom: 0.8rem; font-weight: 600;">
+                        #{goal.name}
+                    </h3>
+
+                    <!-- Horizontal Divider -->
+                    <hr style="border: 0; border-top: 1px solid #ccc; margin: 0.5rem 0 1rem 0;" />
+                    <!-- Details Row -->
+                    <div class="p-d-flex p-flex-wrap p-mb-2" style="font-size: 0.9rem; color: #444;">
+
+                        <div class="p-d-flex p-flex-column p-ai-center p-pr-3 "
+                             style="border-right: 1px solid #ccc; margin-right: 1rem;">
+                            <span style="font-weight: 600;">Weight</span>
+                            <span style="color: #2155A3 ; margin: 5px" >#{goal.contributionWeight}%</span>
+                        </div>
+
+                        <div class="p-d-flex p-flex-column p-ai-center p-pr-3 p-mx-3"
+                             style="border-right: 1px solid #ccc; margin-right: 1rem;">
+                            <span style="font-weight: 600;">Created by</span>
+                            <span style="color: #2155A3 ; margin: 5px"  >#{goal.createdBy}</span>
+                        </div>
+
+                        <div class="p-d-flex p-flex-column p-ai-center p-mx-3">
+                            <span style="font-weight: 600;">Created on</span>
+                            <h:outputText value="#{goal.dateCreated}" style="color: #2155A3 ; margin: 5px" >
+                                <f:convertDateTime pattern="dd MMM yyyy"/>
+                            </h:outputText>
+                        </div>
+
+                    </div>
+
+
+                    <!-- Actions -->
+                    <div class="p-d-flex p-jc-end p-mt-2">
+                        <p:commandButton value="View" icon="pi pi-eye"
+                                         styleClass="ui-button-secondary p-mr-2" />
+                        <p:commandButton value="Edit" icon="pi pi-pencil"
+                                         styleClass="ui-button-info" />
+                    </div>
+
+                </div>
+            </ui:repeat>
+
+            <!-- Pagination -->
+            <div class="p-d-flex p-jc-between p-mt-3">
+                <p:commandLink value="← Previous" update="@form"/>
+                <p:commandLink value="Next →" update="@form"/>
+            </div>
+
+        </h:form>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
### Description
This PR introduces the complete user interface for managing Team Goals. It provides a view to list, create, edit, and delete goals at the department level, ensuring they are aligned with overarching organization goals.
Key additions:

- A new page to display all department goals, typically filterable by department.

- A dialog form for creating and editing goals, including the ability to link them to a parent Organization Goal.

- A navigation link in the "Goal Management" menu to access the new page.

### Type of change

- [ ] New feature (non-breaking change which adds functionality)

### How can this be Tested?
Login as a user with the team lead role 
Navigate to the new Manage Team -> Goals  via the main menu.
Verify that all existing goals are displayed correctly.
Click the "Set Goal" button, select a parent Department Goal, fill out the form, and click "Save". Confirm the new goal appears.
Click the "Edit" button on any goal, make a change, and save. Confirm the list updates.