### PR TITLE
feat: Add Organizational KPIs with Separation of Concerns

### DIFF
--- a/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/kpis/KPI.java
+++ b/backend/kpi-tracker-models/src/main/java/org/pahappa/systems/kpiTracker/models/kpis/KPI.java
@@ -1,6 +1,7 @@
 package org.pahappa.systems.kpiTracker.models.kpis;
 
 import org.pahappa.systems.kpiTracker.models.goals.DepartmentGoal;
+import org.pahappa.systems.kpiTracker.models.goals.OrganizationGoal;
 import org.pahappa.systems.kpiTracker.models.goals.TeamGoal;
 import org.pahappa.systems.kpiTracker.models.systemSetup.enums.Frequency;
 import org.pahappa.systems.kpiTracker.models.systemSetup.enums.MeasurementUnit;
@@ -24,6 +25,10 @@ public class KPI extends BaseEntity {
     private Date lastUpdated;
 
     // References to different goal types
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_goal_id", nullable = true)
+    private OrganizationGoal organizationGoal;
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_goal_id", nullable = true)
     private DepartmentGoal departmentGoal;
@@ -122,6 +127,14 @@ public class KPI extends BaseEntity {
 
     public void setLastUpdated(Date lastUpdated) {
         this.lastUpdated = lastUpdated;
+    }
+
+    public OrganizationGoal getOrganizationGoal() {
+        return organizationGoal;
+    }
+
+    public void setOrganizationGoal(OrganizationGoal organizationGoal) {
+        this.organizationGoal = organizationGoal;
     }
 
     public DepartmentGoal getDepartmentGoal() {

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/security/HyperLinks.java
@@ -31,6 +31,8 @@ public class HyperLinks {
     // KPI-related constants
     public static final String KPIS_VIEW = "/pages/kpis/KPIView.xhtml?faces-redirect=true";
     public static final String KPI_FORM_DIALOG = "/pages/kpis/KPIForm.xhtml";
+    public static final String ORGANIZATIONAL_KPIS_VIEW = "/pages/kpis/OrganizationalKPIView.xhtml?faces-redirect=true";
+    public static final String ORGANIZATIONAL_KPI_FORM_DIALOG = "/pages/kpis/OrganizationalKPIForm.xhtml";
 
     // Activity-related constants
     public static final String ACTIVITIES_VIEW = "/pages/activities/ActivitiesView.xhtml?faces-redirect=true";

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/kpis/OrganizationalKPIForm.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/kpis/OrganizationalKPIForm.java
@@ -1,0 +1,169 @@
+package org.pahappa.systems.kpiTracker.views.kpis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.goals.OrganizationGoalService;
+import org.pahappa.systems.kpiTracker.core.services.kpis.KpisService;
+import org.pahappa.systems.kpiTracker.models.goals.OrganizationGoal;
+import org.pahappa.systems.kpiTracker.models.kpis.KPI;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.Frequency;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.MeasurementUnit;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.pahappa.systems.kpiTracker.views.dialogs.DialogForm;
+import org.sers.webutils.model.exception.OperationFailedException;
+import org.sers.webutils.model.exception.ValidationFailedException;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.util.Arrays;
+import java.util.List;
+
+@ManagedBean(name = "organizationalKpiForm", eager = true)
+@Getter
+@Setter
+@SessionScoped
+public class OrganizationalKPIForm extends DialogForm<KPI> {
+
+    private static final long serialVersionUID = 1L;
+    
+    private KpisService kpisService;
+    private OrganizationGoalService organizationGoalService;
+    
+    private List<OrganizationGoal> organizationGoals;
+    private List<MeasurementUnit> measurementUnits;
+    private List<Frequency> frequencies;
+    
+    private OrganizationGoal selectedOrganizationGoal;
+    
+    // Add edit field like user dialogs
+    private boolean edit;
+
+    public OrganizationalKPIForm() {
+        super(HyperLinks.ORGANIZATIONAL_KPI_FORM_DIALOG, 700, 600);
+    }
+
+    @PostConstruct
+    public void init() {
+        this.kpisService = ApplicationContextProvider.getBean(KpisService.class);
+        this.organizationGoalService = ApplicationContextProvider.getBean(OrganizationGoalService.class);
+        
+        loadData();
+        resetModal();
+    }
+
+    private void loadData() {
+        try {
+            this.organizationGoals = organizationGoalService.getAllInstances();
+        } catch (Exception e) {
+            this.organizationGoals = Arrays.asList();
+        }
+        
+        try {
+            this.measurementUnits = Arrays.asList(MeasurementUnit.values());
+        } catch (Exception e) {
+            this.measurementUnits = Arrays.asList();
+        }
+        
+        try {
+            this.frequencies = Arrays.asList(Frequency.values());
+        } catch (Exception e) {
+            this.frequencies = Arrays.asList();
+        }
+    }
+
+    @Override
+    public void persist() throws ValidationFailedException, OperationFailedException {
+        try {
+            validateForm();
+            
+            // Set the organization goal (clear other goal types)
+            if (selectedOrganizationGoal != null) {
+                model.setOrganizationGoal(selectedOrganizationGoal);
+                model.setDepartmentGoal(null);
+                model.setTeamGoal(null);
+            }
+            
+            kpisService.saveInstance(super.model);
+        } catch (ValidationFailedException e) {
+            UiUtils.ComposeFailure("Validation Error", e.getMessage());
+            throw e;
+        } catch (OperationFailedException e) {
+            UiUtils.ComposeFailure("Operation Error", e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            UiUtils.ComposeFailure("Error", "Failed to save organizational KPI: " + e.getMessage());
+            throw new OperationFailedException("Failed to save organizational KPI: " + e.getMessage());
+        }
+    }
+
+    private void validateForm() throws ValidationFailedException {
+        if (model.getName() == null || model.getName().trim().isEmpty()) {
+            throw new ValidationFailedException("KPI name is required.");
+        }
+        
+        if (selectedOrganizationGoal == null) {
+            throw new ValidationFailedException("Organization goal is required.");
+        }
+        
+        if (model.getMeasurementUnit() == null) {
+            throw new ValidationFailedException("Measurement unit is required.");
+        }
+        
+        if (model.getFrequency() == null) {
+            throw new ValidationFailedException("Frequency is required.");
+        }
+        
+        if (model.getTargetValue() == null) {
+            throw new ValidationFailedException("Target value is required.");
+        }
+        
+        if (model.getStartDate() == null) {
+            throw new ValidationFailedException("Start date is required.");
+        }
+        
+        if (model.getEndDate() == null) {
+            throw new ValidationFailedException("End date is required.");
+        }
+        
+        if (model.getEndDate().before(model.getStartDate())) {
+            throw new ValidationFailedException("End date cannot be before start date.");
+        }
+    }
+
+    @Override
+    public void resetModal() {
+        super.resetModal();
+        super.model = new KPI();
+        setEdit(false);
+        clearSelections();
+    }
+
+    @Override
+    public void setFormProperties() {
+        super.setFormProperties();
+        if (this.model != null && this.model.getId() != null) {
+            this.edit = true;
+            // Set selections based on existing model
+            if (model.getOrganizationGoal() != null) {
+                selectedOrganizationGoal = model.getOrganizationGoal();
+            }
+        } else {
+            this.edit = false;
+        }
+    }
+
+    private void clearSelections() {
+        selectedOrganizationGoal = null;
+    }
+
+    public void show() {
+        super.show(null);
+    }
+
+    public void hide() {
+        super.hide();
+    }
+}

--- a/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/kpis/OrganizationalKPIView.java
+++ b/frontend/kpi-tracker-views/src/main/java/org/pahappa/systems/kpiTracker/views/kpis/OrganizationalKPIView.java
@@ -1,0 +1,190 @@
+package org.pahappa.systems.kpiTracker.views.kpis;
+
+import com.googlecode.genericdao.search.Search;
+import lombok.Getter;
+import lombok.Setter;
+import org.pahappa.systems.kpiTracker.core.services.kpis.KpisService;
+import org.pahappa.systems.kpiTracker.models.kpis.KPI;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.Frequency;
+import org.pahappa.systems.kpiTracker.models.systemSetup.enums.MeasurementUnit;
+import org.pahappa.systems.kpiTracker.security.HyperLinks;
+import org.pahappa.systems.kpiTracker.security.UiUtils;
+import org.sers.webutils.client.views.presenters.ViewPath;
+import org.sers.webutils.model.RecordStatus;
+import org.sers.webutils.server.core.service.excel.reports.ExcelReport;
+import org.sers.webutils.server.core.utils.ApplicationContextProvider;
+
+import javax.annotation.PostConstruct;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.SessionScoped;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ManagedBean(name = "organizationalKpiView")
+@Getter
+@Setter
+@SessionScoped
+@ViewPath(path = HyperLinks.ORGANIZATIONAL_KPIS_VIEW)
+public class OrganizationalKPIView implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(OrganizationalKPIView.class.getSimpleName());
+
+    private KpisService kpisService;
+    private List<KPI> dataModels;
+    private String searchTerm;
+    private Date createdFrom, createdTo;
+    private String dataEmptyMessage = "No organizational KPIs found.";
+    private KPI selectedKPI;
+    
+    // Filter properties
+    private List<MeasurementUnit> measurementUnits;
+    private List<Frequency> frequencies;
+    private MeasurementUnit selectedMeasurementUnit;
+    private Frequency selectedFrequency;
+
+    // Statistics
+    private int totalKpis;
+    private int activeKpis;
+    private int onTrackKpis;
+    private int behindScheduleKpis;
+
+    @PostConstruct
+    public void init() {
+        kpisService = ApplicationContextProvider.getBean(KpisService.class);
+        
+        // Initialize enum lists for filters
+        this.measurementUnits = Arrays.asList(MeasurementUnit.values());
+        this.frequencies = Arrays.asList(Frequency.values());
+        
+        reloadFilterReset();
+    }
+
+    public void reloadFilterReset() {
+        try {
+            Search search = new Search();
+            search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+            search.addFilterNotNull("organizationGoal");
+            
+            // Apply filters if set
+            if (searchTerm != null && !searchTerm.trim().isEmpty()) {
+                search.addFilterLike("name", "%" + searchTerm.trim() + "%");
+            }
+            
+            if (selectedMeasurementUnit != null) {
+                search.addFilterEqual("measurementUnit", selectedMeasurementUnit);
+            }
+            
+            if (selectedFrequency != null) {
+                search.addFilterEqual("frequency", selectedFrequency);
+            }
+            
+            if (createdFrom != null) {
+                search.addFilterGreaterOrEqual("dateCreated", createdFrom);
+            }
+            
+            if (createdTo != null) {
+                search.addFilterLessOrEqual("dateCreated", createdTo);
+            }
+            
+            this.dataModels = kpisService.getInstances(search, 0, 0);
+            calculateStatistics();
+            
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error loading organizational KPIs", e);
+            UiUtils.ComposeFailure("Error", "Failed to load organizational KPIs: " + e.getMessage());
+            this.dataModels = Arrays.asList();
+        }
+    }
+
+    public void reloadFromDB() {
+        try {
+            Search search = new Search();
+            search.addFilterEqual("recordStatus", RecordStatus.ACTIVE);
+            search.addFilterNotNull("organizationGoal");
+            
+            // Apply filters if set
+            if (searchTerm != null && !searchTerm.trim().isEmpty()) {
+                search.addFilterLike("name", "%" + searchTerm.trim() + "%");
+            }
+            
+            if (selectedMeasurementUnit != null) {
+                search.addFilterEqual("measurementUnit", selectedMeasurementUnit);
+            }
+            
+            if (selectedFrequency != null) {
+                search.addFilterEqual("frequency", selectedFrequency);
+            }
+            
+            if (createdFrom != null) {
+                search.addFilterGreaterOrEqual("dateCreated", createdFrom);
+            }
+            
+            if (createdTo != null) {
+                search.addFilterLessOrEqual("dateCreated", createdTo);
+            }
+            
+            this.dataModels = kpisService.getInstances(search, 0, 0);
+            calculateStatistics();
+            
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error reloading organizational KPIs", e);
+            UiUtils.ComposeFailure("Error", "Failed to reload organizational KPIs: " + e.getMessage());
+            this.dataModels = Arrays.asList();
+        }
+    }
+
+    private void calculateStatistics() {
+        if (dataModels == null) {
+            this.totalKpis = 0;
+            this.activeKpis = 0;
+            this.onTrackKpis = 0;
+            this.behindScheduleKpis = 0;
+            return;
+        }
+
+        this.totalKpis = dataModels.size();
+        this.activeKpis = (int) dataModels.stream()
+                .filter(k -> RecordStatus.ACTIVE.equals(k.getRecordStatus()))
+                .count();
+        
+        this.onTrackKpis = (int) dataModels.stream()
+                .filter(k -> k.getAccomplishmentPercentage() != null && k.getAccomplishmentPercentage() >= 80)
+                .count();
+        
+        this.behindScheduleKpis = (int) dataModels.stream()
+                .filter(k -> k.getAccomplishmentPercentage() != null && k.getAccomplishmentPercentage() < 50)
+                .count();
+    }
+
+    public void clearFilters() {
+        this.searchTerm = null;
+        this.selectedMeasurementUnit = null;
+        this.selectedFrequency = null;
+        this.createdFrom = null;
+        this.createdTo = null;
+        reloadFilterReset();
+    }
+
+    public void search() {
+        reloadFromDB();
+    }
+
+    public void deleteSelectedKPI(KPI kpi) {
+        try {
+            if (kpi != null) {
+                kpi.setRecordStatus(RecordStatus.DELETED);
+                kpisService.saveInstance(kpi);
+                UiUtils.showMessageBox("Success", "KPI deleted successfully.");
+                reloadFilterReset();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error deleting KPI", e);
+            UiUtils.ComposeFailure("Error", "Failed to delete KPI: " + e.getMessage());
+        }
+    }
+}

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/californiatemplate/sidebar.xhtml
@@ -33,6 +33,9 @@
                         <p:menuitem id="allKPIs" value="All KPIs"
                                     rendered="#{dashboard.loggedinUser.hasRole('ROLE_ADMINISTRATOR')}"
                                     outcome="/pages/kpis/KPIView" />
+                        <p:menuitem id="organizationalKPIs" value="Organizational KPIs"
+                                    rendered="#{dashboard.loggedinUser.hasRole('ROLE_ADMINISTRATOR')}"
+                                    outcome="/pages/kpis/OrganizationalKPIView" />
                         <p:menuitem id="departmentKPIs" value="Department KPIs"
                                     rendered="#{dashboard.loggedinUser.hasRole('DEPT_LEAD')}"
                                     outcome="/pages/kpis/DepartmentKPIView" />

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/DepartmentKPIView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/DepartmentKPIView.xhtml
@@ -93,6 +93,13 @@
                                 </p:commandButton>
                             </div>
                         </div>
+
+                        <!-- Clear Filters Button -->
+                        <div class="p-grid" style="margin-top: 1rem;">
+                            <div class="p-col-12">
+                                <p:commandButton value="Clear Filters" icon="fa fa-times" styleClass="ui-button-outlined ui-button-secondary" actionListener="#{departmentKPIView.clearFilters}" update="departmentKPIsTable" />
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Department KPIs Data Table -->

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/KPIView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/KPIView.xhtml
@@ -5,10 +5,72 @@
                 xmlns:p="http://primefaces.org/ui"
                 template="/pages/californiatemplate/template.xhtml">
 
+    <ui:define name="head">
+        <style type="text/css">
+            .activity-nav-card {
+                cursor: pointer;
+                transition: all 0.3s ease;
+                border: 1px solid #e0e0e0;
+            }
+            .activity-nav-card:hover {
+                transform: translateY(-2px);
+                box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+            }
+        </style>
+    </ui:define>
+
     <ui:define name="content">
         <div class="ui-g ui-fluid">
             <div class="ui-g-12">
                 <h:form id="kpiView" enctype="multipart/form-data">
+
+                    <!-- KPI Type Navigation -->
+                    <div class="card">
+                        <h5>KPI Management</h5>
+                        <p>Select the type of KPIs you want to manage:</p>
+                        
+                        <div class="p-grid">
+                            <div class="p-col-12 p-md-3">
+                                <div class="card activity-nav-card" onclick="window.location.href='#{request.contextPath}/pages/kpis/OrganizationalKPIView.xhtml'">
+                                    <div class="text-center">
+                                        <i class="pi pi-globe text-green-500 text-4xl mb-3"></i>
+                                        <h6>Organizational KPIs</h6>
+                                        <p class="text-500">Manage organization-wide KPIs</p>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="p-col-12 p-md-3">
+                                <div class="card activity-nav-card" onclick="window.location.href='#{request.contextPath}/pages/kpis/DepartmentKPIView.xhtml'">
+                                    <div class="text-center">
+                                        <i class="pi pi-building text-blue-500 text-4xl mb-3"></i>
+                                        <h6>Department KPIs</h6>
+                                        <p class="text-500">Manage department-level KPIs</p>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="p-col-12 p-md-3">
+                                <div class="card activity-nav-card" onclick="window.location.href='#{request.contextPath}/pages/kpis/TeamKPIView.xhtml'">
+                                    <div class="text-center">
+                                        <i class="pi pi-users text-purple-500 text-4xl mb-3"></i>
+                                        <h6>Team KPIs</h6>
+                                        <p class="text-500">Manage team-level KPIs</p>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="p-col-12 p-md-3">
+                                <div class="card activity-nav-card" onclick="window.location.href='#{request.contextPath}/pages/kpis/KPIView.xhtml'">
+                                    <div class="text-center">
+                                        <i class="pi pi-list text-orange-500 text-4xl mb-3"></i>
+                                        <h6>All KPIs</h6>
+                                        <p class="text-500">View all system KPIs</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
 
                     <div class="p-grid overlay-demo">
                         <div class="p-col-12 p-md-3">
@@ -92,6 +154,13 @@
                                 </p:commandButton>
                             </div>
                         </div>
+
+                        <!-- Clear Filters Button -->
+                        <div class="p-grid" style="margin-top: 1rem;">
+                            <div class="p-col-12">
+                                <p:commandButton value="Clear Filters" icon="fa fa-times" styleClass="ui-button-outlined ui-button-secondary" actionListener="#{kpiView.clearFilters}" update="kpisTable" />
+                            </div>
+                        </div>
                     </div>
 
                     <div class="card" style="margin-top:1rem">
@@ -105,21 +174,21 @@
 
                             <f:facet name="header">
                                 <div class="p-d-flex p-jc-between">
-                                    <div>
-                                        <span class="table-header-text">Key Performance Indicators</span>
-                                    </div>
-                                    <div>
-                                                                                    <p:commandButton value="Add KPI" process="@this"
-                                                         icon="fa fa-plus"
-                                                         ajax="false"
-                                                         styleClass="ui-button-success" immediate="true"
-                                                         actionListener="#{kpiForm.show}">
-                                            <f:setPropertyActionListener value="#{null}" target="#{kpiForm.model}" />
-                                            <p:ajax event="dialogReturn"
-                                                    listener="#{kpiView.reloadFilterReset}"
-                                                    update="kpisTable" />
-                                        </p:commandButton>
-                                    </div>
+                                                                <div>
+                                <span class="table-header-text">All System KPIs</span>
+                            </div>
+                            <div>
+                                <p:commandButton value="Add System KPI" process="@this"
+                                                 icon="fa fa-plus"
+                                                 ajax="false"
+                                                 styleClass="ui-button-success" immediate="true"
+                                                 actionListener="#{kpiForm.show}">
+                                    <f:setPropertyActionListener value="#{null}" target="#{kpiForm.model}" />
+                                    <p:ajax event="dialogReturn"
+                                            listener="#{kpiView.reloadFilterReset}"
+                                            update="kpisTable" />
+                                </p:commandButton>
+                            </div>
                                 </div>
                             </f:facet>
 
@@ -128,12 +197,20 @@
                             </p:column>
 
                         <!-- KPI Name Column -->
-                        <p:column headerText="KPI Name">
-                            <h:outputText value="#{kpi.name}" />
-                        </p:column>
+                                                    <p:column headerText="KPI Name">
+                                <h:outputText value="#{kpi.name}" />
+                            </p:column>
 
-                        <!-- Measurement Unit Column -->
-                        <p:column headerText="Unit">
+                            <p:column headerText="Goal Type">
+                                <h:outputText value="#{kpi.organizationGoal != null ? 'Organization' : (kpi.departmentGoal != null ? 'Department' : (kpi.teamGoal != null ? 'Team' : 'N/A'))}" />
+                            </p:column>
+
+                            <p:column headerText="Goal Name">
+                                <h:outputText value="#{kpi.organizationGoal != null ? kpi.organizationGoal.name : (kpi.departmentGoal != null ? kpi.departmentGoal.name : (kpi.teamGoal != null ? kpi.teamGoal.name : 'N/A'))}" />
+                            </p:column>
+
+                            <!-- Measurement Unit Column -->
+                            <p:column headerText="Unit">
                             <h:outputText value="#{kpi.measurementUnit != null ? kpi.measurementUnit.displayName : 'N/A'}" />
                         </p:column>
 

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/OrganizationalKPIForm.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/OrganizationalKPIForm.xhtml
@@ -1,0 +1,108 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/dialog-template.xhtml">
+
+    <ui:define name="head">
+        <style type="text/css">
+            .capitalized {
+                text-transform: capitalize;
+            }
+        </style>
+    </ui:define>
+
+    <ui:define name="content">
+        <title>Add Organizational KPI</title>
+        <h:form id="organizationalKpiForm" style="height: 600px" styleClass="card">
+            <div class="p-grid ui-fluid" style="display:flex">
+                
+                <div class="ui-col-12 ui-md-6">
+                    <h5>KPI Name *</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputText value="#{organizationalKpiForm.model.name}" required="true" styleClass="ui-fluid" />
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Organization Goal *</h5>
+                    <div class="ui-inputgroup">
+                        <p:selectOneMenu value="#{organizationalKpiForm.selectedOrganizationGoal}"
+                                         converter="organizationGoalConverter" filter="true"
+                                         effect="fold" required="true">
+                            <f:selectItem itemLabel="Select organization goal" itemValue="" />
+                            <f:selectItems value="#{organizationalKpiForm.organizationGoals}" var="goal" itemLabel="#{goal.name}" itemValue="#{goal}"/>
+                        </p:selectOneMenu>
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Measurement Unit *</h5>
+                    <div class="ui-inputgroup">
+                        <p:selectOneMenu value="#{organizationalKpiForm.model.measurementUnit}"
+                                         converter="measurementUnitConverter" effect="fold" required="true">
+                            <f:selectItem itemLabel="Select measurement unit" itemValue="" />
+                            <f:selectItems value="#{organizationalKpiForm.measurementUnits}" var="unit" itemLabel="#{unit.displayName}" itemValue="#{unit}"/>
+                        </p:selectOneMenu>
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Frequency *</h5>
+                    <div class="ui-inputgroup">
+                        <p:selectOneMenu value="#{organizationalKpiForm.model.frequency}"
+                                         converter="frequencyConverter" effect="fold" required="true">
+                            <f:selectItem itemLabel="Select frequency" itemValue="" />
+                            <f:selectItems value="#{organizationalKpiForm.frequencies}" var="freq" itemLabel="#{freq.displayName}" itemValue="#{freq}"/>
+                        </p:selectOneMenu>
+                    </div>
+                </div>
+
+                <hr></hr>
+                <div class="ui-col-12 ui-md-4">
+                    <h5>Target Value *</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputNumber value="#{organizationalKpiForm.model.targetValue}" required="true" styleClass="ui-fluid" />
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-4">
+                    <h5>Current Value</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputNumber value="#{organizationalKpiForm.model.currentValue}" styleClass="ui-fluid" />
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-4">
+                    <h5>Accomplishment %</h5>
+                    <div class="ui-inputgroup">
+                        <p:inputNumber value="#{organizationalKpiForm.model.accomplishmentPercentage}" 
+                                       minValue="0" maxValue="100" styleClass="ui-fluid" />
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>Start Date *</h5>
+                    <div class="ui-inputgroup">
+                        <p:calendar value="#{organizationalKpiForm.model.startDate}" showTime="false" pattern="MM/dd/yyyy" required="true" />
+                    </div>
+                </div>
+
+                <div class="ui-col-12 ui-md-6">
+                    <h5>End Date *</h5>
+                    <div class="ui-inputgroup">
+                        <p:calendar value="#{organizationalKpiForm.model.endDate}" showTime="false" pattern="MM/dd/yyyy" required="true" />
+                    </div>
+                </div>
+
+                <div class="ui-col-12" style="margin-top: 2rem; text-align: center;">
+                    <p:commandButton value="Save" icon="fa fa-save" styleClass="ui-button-success" 
+                                     actionListener="#{organizationalKpiForm.save}" update="@form" />
+                    <p:commandButton value="Cancel" icon="fa fa-times" styleClass="ui-button-secondary" 
+                                     action="#{organizationalKpiForm.hide}" style="margin-left: 10px;" />
+                </div>
+            </div>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/OrganizationalKPIView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/OrganizationalKPIView.xhtml
@@ -1,0 +1,262 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:p="http://primefaces.org/ui"
+                template="/pages/californiatemplate/template.xhtml">
+
+    <ui:define name="head">
+        <style type="text/css">
+            .capitalized {
+                text-transform: capitalize;
+            }
+            .activity-nav-card {
+                cursor: pointer;
+                transition: all 0.3s ease;
+                border: 1px solid #e0e0e0;
+            }
+            .activity-nav-card:hover {
+                transform: translateY(-2px);
+                box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+            }
+        </style>
+    </ui:define>
+
+    <ui:define name="content">
+        <div class="ui-g ui-fluid">
+            <div class="ui-g-12">
+                <h:form id="organizationalKpiView" enctype="multipart/form-data">
+
+                    <!-- Header Section -->
+                    <div class="surface-card shadow-2 p-4 border-round mb-4">
+                        <div class="flex align-items-center">
+                            <i class="pi pi-globe text-green-500 text-2xl mr-3"></i>
+                            <div>
+                                <h6 class="m-0">Organizational KPIs</h6>
+                                <p class="text-500 m-0">Organization-wide Key Performance Indicators Management</p>
+                                <p class="text-400 m-0">Strategic KPIs linked to organization goals</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Statistics Cards -->
+                    <div class="p-grid overlay-demo">
+                        <div class="p-col-12 p-md-3">
+                            <div class="card">
+                                <h:outputText value="Total Organizational KPIs" />
+                                <h2 class="p-text-right">#{organizationalKpiView.totalKpis}</h2>
+                            </div>
+                        </div>
+                        <div class="p-col-12 p-md-3">
+                            <div class="card">
+                                <h:outputText value="Active KPIs" />
+                                <h2 class="p-text-right">#{organizationalKpiView.activeKpis}</h2>
+                            </div>
+                        </div>
+                        <div class="p-col-12 p-md-3">
+                            <div class="card">
+                                <h:outputText value="On Track" />
+                                <h2 class="p-text-right">#{organizationalKpiView.onTrackKpis}</h2>
+                            </div>
+                        </div>
+                        <div class="p-col-12 p-md-3">
+                            <div class="card">
+                                <h:outputText value="Behind Schedule" />
+                                <h2 class="p-text-right">#{organizationalKpiView.behindScheduleKpis}</h2>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Search and Filter Section -->
+                    <div class="card">
+                        <h:outputText value="Filters" />
+                        <p:growl id="messages" showDetail="true" />
+                        <div class="p-grid">
+                            <div class="p-col-12 p-md-6 p-lg-3">
+                                <p:inputText id="searchTerm" required="false"
+                                             value="#{organizationalKpiView.searchTerm}" placeholder="Search KPIs ..."
+                                             onkeyup="#{organizationalKpiView.reloadFilterReset()}">
+                                    <p:ajax event="keyup"
+                                            update="organizationalKpisTable"
+                                            listener="#{organizationalKpiView.reloadFilterReset()}" />
+                                </p:inputText>
+                            </div>
+
+                            <div class="p-col-12 p-md-6 p-lg-3">
+                                <p:selectOneMenu id="measurementUnit" label="Filter by Measurement Unit"
+                                                 title="Filter by Measurement Unit" value="#{organizationalKpiView.selectedMeasurementUnit}"
+                                                 style="height: 100%" converter="measurementUnitConverter">
+                                    <f:selectItem itemLabel="All Units" value="#{null}" />
+                                    <f:selectItems value="#{organizationalKpiView.measurementUnits}" var="unit" itemLabel="#{unit.displayName}" itemValue="#{unit}"/>
+                                    <p:ajax event="change" update="organizationalKpisTable"
+                                            listener="#{organizationalKpiView.reloadFilterReset()}" />
+                                </p:selectOneMenu>
+                            </div>
+
+                            <div class="p-col-12 p-md-6 p-lg-3">
+                                <p:selectOneMenu id="frequency" label="Filter by Frequency"
+                                                 title="Filter by Frequency" value="#{organizationalKpiView.selectedFrequency}"
+                                                 style="height: 100%" converter="frequencyConverter">
+                                    <f:selectItem itemLabel="All Frequencies" value="#{null}" />
+                                    <f:selectItems value="#{organizationalKpiView.frequencies}" var="freq" itemLabel="#{freq.displayName}" itemValue="#{freq}"/>
+                                    <p:ajax event="change" update="organizationalKpisTable"
+                                            listener="#{organizationalKpiView.reloadFilterReset()}" />
+                                </p:selectOneMenu>
+                            </div>
+                            <div class="p-col-12 p-md-6 p-lg-3">
+                                <p:calendar placeholder="From Date Created"
+                                            value="#{organizationalKpiView.createdFrom}" inputStyleClass="Wid100"
+                                            navigator="true" pattern="dd MMM, yyyy" />
+                            </div>
+                            <div class="p-col-12 p-md-6 p-lg-3">
+                                <p:calendar placeholder="To Date Created"
+                                            value="#{organizationalKpiView.createdTo}" inputStyleClass="Wid100"
+                                            navigator="true" pattern="dd MMM, yyyy" />
+                            </div>
+
+                            <div class="p-col-12 p-md-6 p-lg-1">
+                                <p:commandButton icon="fa fa-search"
+                                                 styleClass="ui-button-success" id="searchBtn"
+                                                 style="margin-right: 18px" update="organizationalKpisTable"
+                                                 actionListener="#{organizationalKpiView.reloadFilterReset()}">
+                                </p:commandButton>
+                            </div>
+                        </div>
+
+                        <!-- Clear Filters Button -->
+                        <div class="p-grid" style="margin-top: 1rem;">
+                            <div class="p-col-12">
+                                <p:commandButton value="Clear Filters" icon="fa fa-times" styleClass="ui-button-outlined ui-button-secondary" actionListener="#{organizationalKpiView.clearFilters}" update="organizationalKpisTable" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- KPIs Table -->
+                    <div class="card" style="margin-top:1rem">
+                        <p:dataTable id="organizationalKpisTable" var="kpi" value="#{organizationalKpiView.dataModels}"
+                                     widgetVar="organizationalKpisTable"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
+                                     paginator="true" lazy="true" rows="20"
+                                     emptyMessage="#{organizationalKpiView.dataEmptyMessage}"
+                                     paginatorPosition="bottom" paginatorAlwaysVisible="false"
+                                     rowIndexVar="row" reflow="true" styleClass="TableAlgnment">
+
+                            <f:facet name="header">
+                                <div class="p-d-flex p-jc-between">
+                                    <div>
+                                        <span class="table-header-text">Organizational Key Performance Indicators</span>
+                                    </div>
+                                    <div>
+                                        <p:commandButton value="Add Organizational KPI" process="@this"
+                                                         icon="fa fa-plus"
+                                                         ajax="false"
+                                                         styleClass="ui-button-success" immediate="true"
+                                                         actionListener="#{organizationalKpiForm.show}">
+                                            <f:setPropertyActionListener value="#{null}" target="#{organizationalKpiForm.model}" />
+                                            <p:ajax event="dialogReturn"
+                                                    listener="#{organizationalKpiView.reloadFilterReset}"
+                                                    update="organizationalKpisTable" />
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+
+                            <p:column width="30" headerText="No.">
+                                <h:outputText value="#{row + 1}" />
+                            </p:column>
+
+                            <p:column headerText="KPI Name">
+                                <h:outputText value="#{kpi.name}" />
+                            </p:column>
+
+                            <p:column headerText="Organization Goal">
+                                <h:outputText value="#{kpi.organizationGoal != null ? kpi.organizationGoal.name : 'N/A'}" />
+                            </p:column>
+
+                            <p:column headerText="Unit">
+                                <h:outputText value="#{kpi.measurementUnit != null ? kpi.measurementUnit.displayName : 'N/A'}" />
+                            </p:column>
+
+                            <p:column headerText="Target">
+                                <h:outputText value="#{kpi.targetValue}" />
+                            </p:column>
+
+                            <p:column headerText="Current">
+                                <h:outputText value="#{kpi.currentValue}" />
+                            </p:column>
+
+                            <p:column headerText="Accomplishment">
+                                <h:outputText value="#{kpi.accomplishmentPercentage != null ? kpi.accomplishmentPercentage : '0'}%" />
+                            </p:column>
+
+                            <p:column headerText="Frequency">
+                                <h:outputText value="#{kpi.frequency != null ? kpi.frequency.displayName : 'N/A'}" />
+                            </p:column>
+
+                            <p:column headerText="Start Date">
+                                <h:outputText value="#{kpi.startDate}">
+                                    <f:convertDateTime pattern="dd MMM, yyyy" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="End Date">
+                                <h:outputText value="#{kpi.endDate}">
+                                    <f:convertDateTime pattern="dd MMM, yyyy" />
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Status">
+                                <h:outputText value="#{kpi.recordStatus}" />
+                            </p:column>
+
+                            <p:column headerText="Action" width="140" exportable="false" style="text-align:center">
+                                <p:commandButton icon="fa fa-edit" styleClass="ui-button-primary"
+                                                 ajax="false"
+                                                 actionListener="#{organizationalKpiForm.show}">
+                                    <f:setPropertyActionListener value="#{kpi}" target="#{organizationalKpiForm.model}" />
+                                    <p:ajax event="dialogReturn" update="organizationalKpisTable" />
+                                </p:commandButton>
+                                <p:commandButton icon="fa fa-trash" title="Delete"
+                                                 styleClass="ui-button-danger" style="margin-left:5px" ajax="false"
+                                                 actionListener="#{organizationalKpiView.deleteSelectedKPI(kpi)}"
+                                                 update="organizationalKpisTable">
+                                    <p:confirm header="Confirmation"
+                                               message="You are about to delete a KPI. Do you wish to continue?"
+                                               icon="ui-icon-alert" />
+                                </p:commandButton>
+                            </p:column>
+                        </p:dataTable>
+                    </div>
+                </h:form>
+            </div>
+        </div>
+
+        <!-- Organizational KPI Form Dialog -->
+        <ui:include src="OrganizationalKPIForm.xhtml" />
+
+        <!-- Delete Confirmation Dialog -->
+        <p:confirmDialog header="Confirm Delete" message="Are you sure you want to delete this KPI?" 
+                         widgetVar="confirmDelete" showEffect="fade" hideEffect="fade" 
+                         responsive="true" width="350">
+            <p:commandButton value="Yes" type="button" styleClass="ui-button-success" 
+                            action="#{organizationalKpiView.deleteSelectedKPI(organizationalKpiView.selectedKPI)}"
+                            oncomplete="PF('confirmDelete').hide()" />
+            <p:commandButton value="No" type="button" styleClass="ui-button-secondary" 
+                            onclick="PF('confirmDelete').hide()" />
+        </p:confirmDialog>
+        
+        <script type="javascript">
+            function refreshOrganizationalKpiTable() {
+                console.log('Refreshing organizational KPI table...');
+                if (typeof PF !== 'undefined' && PF('organizationalKpisTable')) {
+                    PF('organizationalKpisTable').filter();
+                }
+                setTimeout(function() {
+                    if (typeof PrimeFaces !== 'undefined') {
+                        PrimeFaces.ab({s: 'organizationalKpiView:organizationalKpisTable', u: 'organizationalKpiView:organizationalKpisTable'});
+                    }
+                }, 100);
+            }
+        </script>
+    </ui:define>
+</ui:composition>

--- a/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/TeamKPIView.xhtml
+++ b/frontend/kpi-tracker-web/src/main/webapp/pages/kpis/TeamKPIView.xhtml
@@ -93,6 +93,13 @@
                                 </p:commandButton>
                             </div>
                         </div>
+
+                        <!-- Clear Filters Button -->
+                        <div class="p-grid" style="margin-top: 1rem;">
+                            <div class="p-col-12">
+                                <p:commandButton value="Clear Filters" icon="fa fa-times" styleClass="ui-button-outlined ui-button-secondary" actionListener="#{teamKPIView.clearFilters}" update="teamKPIsTable" />
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Team KPIs Data Table -->


### PR DESCRIPTION
• Create OrganizationalKPIView and OrganizationalKPIForm for organization-wide KPI management with dedicated backing beans and XHTML files.
 • Enhance main KPIView with navigation cards and goal type columns, add clear filters functionality to all KPI views.
 • Update KPI model with organizationGoal field, add organizational KPIs to sidebar navigation, and implement role-based access control


